### PR TITLE
Fix GetMounts, use nil filter to get old behaviour

### DIFF
--- a/system/mount.go
+++ b/system/mount.go
@@ -88,7 +88,7 @@ func (m *DefMount) Filesystem() (string, error) {
 }
 
 func getMount(mountpoint string) (*mount.Info, error) {
-	entries, err := mount.GetMounts()
+	entries, err := mount.GetMounts(nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
GetMounts() behaviour changed, now expects a filter parameter, use nil to get old behaviour.