### PR TITLE
GitHub Actions based CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+---
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+# Each of these can be read|write|none
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  packages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3.0.2
+      - run: ci/build.sh


### PR DESCRIPTION
First commit is just a very skeleton workflow.

This PR is really starting as just an experiment. I'm pretty familiar with GHA, and the experiment part will really be figuring out how to interact with the Make-based build in a nice UX way but also get nice, fast, modern, all-platforms-we-want, not-as-rate-limited-as-travis CI.

If this turns out to be quite easy, then my approach would be to get to parity with all the things Travis does today, _before_ doing anything that Travis does _not_ do that we might _also_ want. I'd want to minimise the amount of time there are 2 CIs in play.

That means changing the in-repo build-automation as little as possible, and if there are things necessary to change, then Travis must stay green. At all points, Travis outcome should agree with GHA outcome. If GHA differs, GHA is probably not quite there yet.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

Related: #649

(I don't think I will aim at everything that #649 wants, like researching other platforms - just getting off Travis).