### PR TITLE
Json schema to provide coding assistance for goss.yaml in IDEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,13 @@ curl -H "Accept: application/vnd.goss-rspecish" localhost:8080/healthz
 
 ### Manually editing Goss files
 
-Goss files can be manually edited to use:
+Goss files can be manually edited to improve readability and expresssiveneess of tests.
+
+A [Json draft 7 schema](https://github.com/json-schema-org/json-schema-spec/blob/draft-07/schema.json) available in [docs/goss-json-schema.yaml](./docs/goss-json-schema.yaml) makes it easier to edit simple goss.yaml files in IDEs, providing usual coding assistance such as inline documentation, completion and static analysis.
+
+For example, to configure the Json schema in JetBrains intellij IDEA, follow [documented instructions](https://www.jetbrains.com/help/idea/json.html#ws_json_schema_add_custom), with arguments such as `schema url=https://raw.githubusercontent.com/goss-org/goss/master/docs/goss-json-schema.yaml`, `schema version=Json schema version 7`, `file path pattern=*/goss.yaml`
+
+In addition, Goss files can also be further manually edited to use:
 
 * [Patterns](https://github.com/goss-org/goss/blob/master/docs/manual.md#patterns)
 * [Advanced Matchers](https://github.com/goss-org/goss/blob/master/docs/manual.md#advanced-matchers)

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ A [Json draft 7 schema](https://github.com/json-schema-org/json-schema-spec/blob
 
 For example, to configure the Json schema in JetBrains intellij IDEA, follow [documented instructions](https://www.jetbrains.com/help/idea/json.html#ws_json_schema_add_custom), with arguments such as `schema url=https://raw.githubusercontent.com/goss-org/goss/master/docs/goss-json-schema.yaml`, `schema version=Json schema version 7`, `file path pattern=*/goss.yaml`
 
-In addition, Goss files can also be further manually edited to use:
+In addition, Goss files can also be further manually edited (without full json support) to use:
 
 * [Patterns](https://github.com/goss-org/goss/blob/master/docs/manual.md#patterns)
 * [Advanced Matchers](https://github.com/goss-org/goss/blob/master/docs/manual.md#advanced-matchers)

--- a/docs/goss-json-schema.yaml
+++ b/docs/goss-json-schema.yaml
@@ -132,7 +132,6 @@ definitions:
       skip:
         type: boolean
         default: false
-
   gossfileTest:
     properties:
       file:
@@ -256,7 +255,6 @@ definitions:
       mtu:
         type: integer
         default: 1500
-
   kernelParamTest:
     description: |
       To see the full list of current values, run sysctl -a.
@@ -266,8 +264,24 @@ definitions:
       value:
         type: string
         default: Linux
-
-
+  matchingTest:
+    properties:
+      content:
+        anyOf:
+        - type: string
+          default: "some string"
+        - type: array
+          default:
+            - 2
+        - type: object
+          default:
+            foo: bar
+            baz: ring
+      matches:
+        anyOf:
+          - type: integer
+          - type: object
+          - type: array
 
   mountTest:
     required:
@@ -573,9 +587,12 @@ properties:
 
   matching:
       type: object
-      description: "test "
+      description: "Validates specified content against a matcher. Best used with Templates."
+      x-intellij-html-description: |
+        Validates specified content against a matcher. Best used with <a href="#templates">Templates</a>.</p>
+        <h4 dir="auto"><a id="user-content-with-templates" class="anchor" aria-hidden="true" href="#with-templates"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
       additionalProperties:
-        $ref: "#/definitions/Test"
+        $ref: "#/definitions/matchingTest"
 
   mount:
       type: object

--- a/docs/goss-json-schema.yaml
+++ b/docs/goss-json-schema.yaml
@@ -1,0 +1,619 @@
+#$schema: "https://json-schema.org/draft/2020-12/schema"
+#$id: "https://github.com/goss-org/goss.json"
+$schema: http://json-schema.org/draft-07/schema#
+title: "Goss-file-schema"
+definitions:
+  commandTest:
+    type: object
+    properties:
+      exit-status:
+        type: integer
+        description: "Validates the exit-status and output of a command"
+      exec:
+        description: "command to execute, defaults to the hash key"
+        type: string
+      stdout:
+        type: array
+        description: "can be a string or pattern, see https://github.com/goss-org/goss/blob/master/docs/manual.md#patterns"
+        items:
+          type: string
+      stderr:
+        type: array
+        description: "can be a string or pattern, see https://github.com/goss-org/goss/blob/master/docs/manual.md#patterns"
+        items:
+          type: string
+      timeout:
+        type: integer
+        description: "in milliseconds"
+      skip:
+        type: boolean
+        default: false
+    required:
+      - exit-status
+  addrTest:
+    required:
+      - reachable
+      - timeout
+    properties:
+      reachable:
+        type: boolean
+        default: true
+      timeout:
+        type: integer
+        default: 500
+        examples:
+          - 500
+          # optional attributes
+      local-address:
+        type: string
+        default: 127.0.0.1
+  dnsTest:
+    required:
+      - resolvable
+    properties:
+      resolvable:
+        type: boolean
+        default: true
+      # optional attributes
+      addrs:
+        description: |
+          list of addresses e.g. ["127.0.0.1", "::1"]
+        type: array
+        items:
+          type: string
+        default: ["127.0.0.1", "::1"]
+      server:
+        description: "Eg 8.8.8.8. Also supports server:port "
+        type: string
+        default: 8.8.8.8
+      timeout:
+        type: integer
+        default: 500
+        description: in milliseconds (Only used when server attribute is provided)
+  fileTest:
+    required:
+      - exists
+    properties:
+      exists:
+        type: boolean
+        default: true
+      mode:
+        type: string
+        default: "0644"
+      size:
+        type: integer
+        default: 2118
+        description: in bytes
+      owner:
+        type: string
+        default: root
+      group:
+        type: string
+        default: root
+      filetype:
+        type: string
+        default: file
+        enum:
+          - file
+          - symlink
+          - directory
+      contains:
+        type: array
+        description: Check file content for these patterns. can be a string or a pattern
+        items:
+          type: string
+          description: string or patterns
+      md5:
+        type: string
+        default: 7c9bb14b3bf178e82c00c2a4398c93cd
+        description: md5 checksum of file
+
+      sha256:
+        type: string
+        default: 7f78ce27859049f725936f7b52c6e25d774012947d915e7b394402cfceb70c4c
+        description: "A stronger checksum alternatives to md5 (recommended)"
+      sha512:
+        type: string
+        default: cb71b1940dc879a3688bd502846bff6316dd537bbe917484964fe0f098e9245d80958258dc3bd6297bf42d5bd978cbe2c03d077d4ed45b2b1ed9cd831ceb1bd0
+        description: "A stronger checksum alternatives to md5 (recommended)"
+      linked-to:
+        type: string
+        default: /usr/sbin/sendmail.sendmail
+      skip:
+        type: boolean
+        default: false
+
+  gossfileTest:
+    properties:
+      file:
+        type: string
+        default: myapp_gossfile.yaml
+      skip:
+        type: boolean
+        default: false
+  groupTest:
+    required:
+      - exists
+    properties:
+      exists:
+        type: boolean
+        default: true
+      gid:
+        type: integer
+        default: 65534
+      skip:
+        type: boolean
+        default: false
+  httpTest:
+    required:
+      - status
+    properties:
+      status:
+        type: integer
+        default: 200
+      allow-insecure:
+        type: boolean
+        default: false
+      no-follow-redirects:
+        type: boolean
+        default: false
+        description: Setting this to true will NOT follow redirects
+      timeout:
+        type: integer
+        default: 1000
+      request-headers:
+        description: |
+          Set request header values, e.g. [ "Content-Type: text/html" ]
+        type: array
+        items:
+          type: string
+        default: [ "Content-Type: text/html" ]
+      headers:
+        type: array
+        description: |
+          Check http response headers for these patterns (e.g. "Content-Type: text/html")
+          NOTE: only the first Host header will be used to set the Request.Host value if multiple are provided.
+        items:
+          type: string
+        default: [ ]
+      request-body:
+        type: object
+        default: '{"key": "value"}'
+        description: request body
+      body:
+        type: array
+        description: Check http response content for these patterns
+      username:
+        type: string
+        description: username for basic auth
+        default: ""
+      password:
+        type: string
+        description: password for basic auth
+        default: ""
+      ca-file:
+        type: string
+        default: ""
+        description: |
+          CA root certs pem file, ex: /etc/ssl/cert.pem
+      cert-file:
+        type: string
+        default: ""
+        description: |
+         certificate file to use for authentication (used with key-file)
+      key-file:
+        type: string
+        default: ""
+        description:  |
+          private-key file to use for authentication (used with cert-file)
+      proxy:
+        type: string
+        default: ""
+        description:  |
+          proxy server to proxy traffic through. Proxy can also be set with environment variables http_proxy.
+      skip:
+        type: boolean
+        default: false
+      method:
+        type: string
+        default: PUT
+        description: http method
+        enum: # See https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods
+        # Note: not yet clear whether goss supports all methods
+          - GET
+          - PUT
+          - HEAD
+          - POST
+          - DELETE
+          - PATCH
+          - CONNECT
+          - OPTIONS
+          - TRACE
+  interfaceTest:
+    required:
+      - exists
+    properties:
+      exists:
+        type: boolean
+        default: true
+      addrs:
+        type: array
+        items:
+          type: string
+        default:
+        - 172.17.0.2/16
+        - fe80::42:acff:fe11:2/64
+      mtu:
+        type: integer
+        default: 1500
+
+  kernelParamTest:
+    description: |
+      To see the full list of current values, run sysctl -a.
+    required:
+      - value
+    properties:
+      value:
+        type: string
+        default: Linux
+
+
+
+  mountTest:
+    required:
+      - exists
+    properties:
+      exists:
+        type: boolean
+        default: true
+      opts:
+        type: array
+        items:
+          type: string
+        default:
+        - rw
+        - relatime
+      source:
+        type: string
+        default: /dev/mapper/fedora-home
+      filesystem:
+        type: string
+        default: xfs
+      usage:
+        description: |
+          % of blocks used in this mountpoint
+        type: object
+        properties:
+          lt:
+            type: integer
+            default: 95
+  packageTest:
+    required:
+      - installed
+    properties:
+      installed:
+        type: boolean
+        default: true
+      versions:
+        type: array
+        items:
+          type: string
+        default:
+        - 2.2.15
+      skip:
+        type: boolean
+        default: false
+  portTest:
+    required:
+      - listening
+    properties:
+      listening:
+        type: boolean
+        default: true
+      ip:
+        description: what IP(s) is it listening on
+        type: array
+        items:
+          type: string
+        default:
+        - 0.0.0.0
+      skip:
+        type: boolean
+        default: false
+  serviceTest:
+    required:
+      - enabled
+      - running
+      - skip
+    properties:
+      enabled:
+        type: boolean
+        default: true
+      running:
+        type: boolean
+        default: true
+      skip:
+        type: boolean
+        default: false
+  userTest:
+    required:
+      - exists
+    properties:
+      exists:
+        type: boolean
+        default: true
+      # optional attributes
+      uid:
+        type: integer
+        default: 65534
+      gid:
+        type: integer
+        default: 65534
+      groups:
+        type: array
+        items:
+          type: string
+        default:
+        - nfsnobody
+      home:
+        type: string
+        default: /var/lib/nfs
+      shell:
+        type: string
+        default: /sbin/nologin
+      skip:
+        type: boolean
+        default: false
+
+description: "A file describing a series of tests"
+type: "object"
+properties:
+  process:
+    type: object
+    description: "test executing a command"
+    additionalProperties:
+      $ref: "#/definitions/commandTest"
+  
+  addr:
+      type: object
+      description: "Validates if a remote address:port are accessible."
+      examples:
+        - tcp://ip-address-or-domain-name:80:
+            reachable: true
+            timeout: 500
+            local-address: 127.0.0.1
+      additionalProperties:
+        $ref: "#/definitions/addrTest"
+
+  dns:
+      type: object
+      description: "Validates that the provided address is resolvable and the addrs it resolves to."
+      x-intellij-html-description: |
+        <p dir="auto">Validates that the provided address is resolvable and the addrs it resolves to.</p>
+        <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">dns</span>:
+          <span class="pl-ent">localhost</span>:
+            <span class="pl-c"><span class="pl-c">#</span> required attributes</span>
+            <span class="pl-ent">resolvable</span>: <span class="pl-c1">true</span>
+            <span class="pl-c"><span class="pl-c">#</span> optional attributes</span>
+            <span class="pl-ent">addrs</span>:
+            - <span class="pl-s">127.0.0.1</span>
+            - <span class="pl-s">::1</span>
+            <span class="pl-ent">server</span>: <span class="pl-s">8.8.8.8 </span><span class="pl-c"><span class="pl-c">#</span> Also supports server:port</span>
+            <span class="pl-ent">timeout</span>: <span class="pl-c1">500</span> <span class="pl-c"><span class="pl-c">#</span> in milliseconds (Only used when server attribute is provided)</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+            <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="dns:
+          localhost:
+            # required attributes
+            resolvable: true
+            # optional attributes
+            addrs:
+            - 127.0.0.1
+            - ::1
+            server: 8.8.8.8 # Also supports server:port
+            timeout: 500 # in milliseconds (Only used when server attribute is provided)" tabindex="0" role="button" style="display: none;">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+            <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+        </svg>
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+            <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+        </svg>
+            </clipboard-copy>
+          </div></div>
+        <p dir="auto">It is possible to validate the following types of DNS records, but requires the <code>server</code> attribute be set:</p>
+        <ul dir="auto">
+        <li>A</li>
+        <li>AAAA</li>
+        <li>CAA</li>
+        <li>CNAME</li>
+        <li>MX</li>
+        <li>NS</li>
+        <li>PTR</li>
+        <li>SRV</li>
+        <li>TXT</li>
+        </ul>
+        <p dir="auto">To validate specific DNS address types, prepend the hostname with the type and a colon, a few examples:</p>
+        <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">dns</span>:
+          <span class="pl-c"><span class="pl-c">#</span> Validate a CNAME record</span>
+          <span class="pl-ent">CNAME:c.dnstest.io</span>:
+            <span class="pl-ent">resolvable</span>: <span class="pl-c1">true</span>
+            <span class="pl-ent">server</span>: <span class="pl-s">208.67.222.222</span>
+            <span class="pl-ent">addrs</span>:
+            - <span class="pl-s"><span class="pl-pds">"</span>a.dnstest.io.<span class="pl-pds">"</span></span>
+
+          <span class="pl-c"><span class="pl-c">#</span> Validate a PTR record</span>
+          <span class="pl-ent">PTR:8.8.8.8</span>:
+            <span class="pl-ent">resolvable</span>: <span class="pl-c1">true</span>
+            <span class="pl-ent">server</span>: <span class="pl-s">8.8.8.8</span>
+            <span class="pl-ent">addrs</span>:
+            - <span class="pl-s"><span class="pl-pds">"</span>dns.google.<span class="pl-pds">"</span></span>
+
+          <span class="pl-c"><span class="pl-c">#</span> Validate and SRV record</span>
+          <span class="pl-ent">SRV:_https._tcp.dnstest.io</span>:
+            <span class="pl-ent">resolvable</span>: <span class="pl-c1">true</span>
+            <span class="pl-ent">server</span>: <span class="pl-s">208.67.222.222</span>
+            <span class="pl-ent">addrs</span>:
+            - <span class="pl-s"><span class="pl-pds">"</span>0 5 443 a.dnstest.io.<span class="pl-pds">"</span></span>
+            - <span class="pl-s"><span class="pl-pds">"</span>10 10 443 b.dnstest.io.<span class="pl-pds">"</span></span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+            <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="dns:
+          # Validate a CNAME record
+          CNAME:c.dnstest.io:
+            resolvable: true
+            server: 208.67.222.222
+            addrs:
+            - &quot;a.dnstest.io.&quot;
+
+          # Validate a PTR record
+          PTR:8.8.8.8:
+            resolvable: true
+            server: 8.8.8.8
+            addrs:
+            - &quot;dns.google.&quot;
+
+          # Validate and SRV record
+          SRV:_https._tcp.dnstest.io:
+            resolvable: true
+            server: 208.67.222.222
+            addrs:
+            - &quot;0 5 443 a.dnstest.io.&quot;
+            - &quot;10 10 443 b.dnstest.io.&quot;" tabindex="0" role="button">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+            <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+        </svg>
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+            <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+        </svg>
+            </clipboard-copy>
+          </div></div>
+        <p dir="auto">Please note that if you want <code>localhost</code> to <strong>only</strong> resolve <code>127.0.0.1</code> you'll need to use <a href="#advanced-matchers">Advanced Matchers</a></p>
+        <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">dns</span>:
+          <span class="pl-ent">localhost</span>:
+            <span class="pl-ent">resolvable</span>: <span class="pl-c1">true</span>
+            <span class="pl-ent">addrs</span>:
+              <span class="pl-ent">consist-of</span>: <span class="pl-s">[127.0.0.1]</span>
+            <span class="pl-ent">timeout</span>: <span class="pl-c1">500</span> <span class="pl-c"><span class="pl-c">#</span> in milliseconds</span>
+      additionalProperties:
+        $ref: "#/definitions/dnsTest"
+
+  file:
+      type: object
+      description: "Validates the state of a file, directory, or symbolic link"
+      additionalProperties:
+        $ref: "#/definitions/fileTest"
+
+  gossfile:
+      type: object
+      description: |
+        Import other gossfiles from this one. This is the best way to maintain a large number of tests, and/or create profiles. See render for more examples. Glob patterns can be also be used to specify matching gossfiles.
+        You can specify the gossfile(s) either as the resource key, or using the 'file' attribute.
+
+        If the 'skip' attribute is true, then the file is not processed. If the filename is a glob pattern, then none of the matching files are processed. Note that this is not the same as skipping the contained resources; any overrides in the referenced gossfile will not be processed, and the resource count will not be incremented. Skipping a gossfile include is the same as omitting the gossfile resource entirely.
+      x-intellij-html-description: |
+        Import other gossfiles from this one. This is the best way to maintain a large number of tests, and/or create profiles. See <a href="#render-r---render-gossfile-after-importing-all-referenced-gossfiles">render</a> for more examples. Glob patterns can be also be used to specify matching gossfiles.</p>
+        <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">gossfile</span>:
+          <span class="pl-ent">myapplication</span>:
+            <span class="pl-ent">file</span>: <span class="pl-s">myapp_gossfile.yaml</span>
+            <span class="pl-ent">skip</span>: <span class="pl-c1">false</span>
+          <span class="pl-s">*.yaml:</span>
+            <span class="pl-ent">skip</span>: <span class="pl-c1">true</span>
+          <span class="pl-ent">goss_httpd.yaml</span>: <span class="pl-s">{}</span>
+          <span class="pl-ent">/etc/goss.d/*.yaml</span>: <span class="pl-s">{}</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+            <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="gossfile:
+          myapplication:
+            file: myapp_gossfile.yaml
+            skip: false
+          *.yaml:
+            skip: true
+          goss_httpd.yaml: {}
+          /etc/goss.d/*.yaml: {}" tabindex="0" role="button" style="display: none;">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+            <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+        </svg>
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+            <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+        </svg>
+            </clipboard-copy>
+          </div></div>
+        <p dir="auto">You can specify the gossfile(s) either as the resource key, or using the 'file' attribute.</p>
+        <p dir="auto">If the 'skip' attribute is true, then the file is not processed.  If the filename is a glob pattern, then none of the matching files are processed.  Note that this is not the same as skipping the contained resources; any overrides in the referenced gossfile will not be processed, and the resource count will not be incremented.  Skipping a gossfile include is the same as omitting the gossfile resource entirely.</p>
+      additionalProperties:
+        $ref: "#/definitions/gossfileTest"
+
+  group:
+      type: object
+      description: "Validates the state of a group"
+      additionalProperties:
+        $ref: "#/definitions/groupTest"
+
+  http:
+      type: object
+      description: "description: Validates network interface values"
+      additionalProperties:
+        $ref: "#/definitions/httpTest"
+
+  interface:
+      type: object
+      description: "test "
+      additionalProperties:
+        $ref: "#/definitions/interfaceTest"
+
+  kernel-param:
+      type: object
+      description: "test "
+      additionalProperties:
+        $ref: "#/definitions/kernelParamTest"
+
+  matching:
+      type: object
+      description: "test "
+      additionalProperties:
+        $ref: "#/definitions/Test"
+
+  mount:
+      type: object
+      description: "Validates mount point attributes."
+      additionalProperties:
+        $ref: "#/definitions/mountTest"
+
+  package:
+      type: object
+      description: |
+        Validates the state of a package"
+        NOTE: this check uses the --package <format> parameter passed on the command line.
+      additionalProperties:
+        $ref: "#/definitions/packageTest"
+
+  port:
+      type: object
+      description: |
+        Validates the state of a local port.
+
+        Note: Goss might consider your port to be listening on tcp6 rather than tcp, try running goss add port .. to see how goss detects it. (explanation)
+      x-intellij-html-description: |
+        <p dir="auto">Validates the state of a local port.</p>
+        <p dir="auto"><strong>Note:</strong> Goss might consider your port to be listening on <code>tcp6</code> rather than <code>tcp</code>, try running <code>goss add port ..</code> to see how goss detects it. (<a href="https://github.com/goss-org/goss/issues/149" data-hovercard-type="issue" data-hovercard-url="/goss-org/goss/issues/149/hovercard">explanation</a>)</p>
+        <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">port</span>:
+          <span class="pl-c"><span class="pl-c">#</span> {tcp,tcp6,udp,udp6}:port_num</span>
+          <span class="pl-ent">tcp:22</span>:
+            <span class="pl-c"><span class="pl-c">#</span> required attributes</span>
+            <span class="pl-ent">listening</span>: <span class="pl-c1">true</span>
+            <span class="pl-c"><span class="pl-c">#</span> optional attributes</span>
+            <span class="pl-ent">ip</span>: <span class="pl-c"><span class="pl-c">#</span> what IP(s) is it listening on</span>
+            - <span class="pl-s">0.0.0.0</span>
+            <span class="pl-ent">skip</span>: <span class="pl-c1">false</span>
+      additionalProperties:
+        $ref: "#/definitions/portTest"
+
+  service:
+      type: object
+      description: "Validates the state of a service."
+      additionalProperties:
+        $ref: "#/definitions/serviceTest"
+
+  user:
+      type: object
+      description: |
+        Validates the state of a user"
+        NOTE: This check is inspecting the contents of local passwd file /etc/passwd, this does not validate remote users (e.g. LDAP).
+      additionalProperties:
+        $ref: "#/definitions/userTest"
+
+

--- a/docs/goss-json-schema.yaml
+++ b/docs/goss-json-schema.yaml
@@ -1,7 +1,8 @@
 $id: "https://github.com/goss-org/goss/master/docs/goss-json-schema.yaml"
 # Note: this schema was authored using intellij support for Json schema version 7
 # providing coding assistance
-# This schema is based on content from https://github.com/goss-org/goss/blob/master/docs/manual.md
+# This schema is based on content from https://github.com/goss-org/goss/blob/master/docs/manual.md and
+#  and https://github.com/goss-org/goss/blob/master/README.md
 # It was tested in intellij against https://github.com/goss-org/goss/master/docs/goss.yaml
 # both for completion and code analysis use-cases.
 # Limitations / missing support
@@ -13,9 +14,18 @@ $id: "https://github.com/goss-org/goss/master/docs/goss-json-schema.yaml"
 $schema: http://json-schema.org/draft-07/schema#
 title: "Goss-file-schema"
 definitions:
+  title:
+    type: string
+    default: "UID must be between 50-100, GID doesn't matter. home is flexible"
+    description: title attribute is persisted when adding other resources with goss add
+  meta:
+    description: meta (arbitrary data) attributes are persisted when adding other resources with goss add
+    type: object
   commandTest:
     type: object
     properties:
+      title: { "$ref":"#definitions/title" }
+      meta: { "$ref":"#definitions/meta" }
       exit-status:
         type: integer
         description: "Validates the exit-status and output of a command"
@@ -147,9 +157,14 @@ definitions:
       exists:
         type: boolean
         default: true
+      uid:
+        type: integer
+        default: 65534
       gid:
         type: integer
         default: 65534
+      groups:
+        type: object
       skip:
         type: boolean
         default: false
@@ -265,6 +280,115 @@ definitions:
         type: string
         default: Linux
   matchingTest:
+    description: "Validates specified content against a matcher. Best used with Templates."
+    x-intellij-html-description: |
+      <p dir="auto">Validates specified content against a matcher. Best used with <a href="#templates">Templates</a>.</p>
+      <h4 dir="auto"><a id="user-content-with-templates" class="anchor" aria-hidden="true" href="#with-templates"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>With <a href="#templates">Templates</a>:</h4>
+      <p dir="auto">Let's say we have a <code>data.json</code> file that gets generated as part of some testing pipeline:</p>
+      <div class="highlight highlight-source-json notranslate position-relative overflow-auto" dir="auto"><pre>{
+        <span class="pl-ent">"instance_count"</span>: <span class="pl-c1">14</span>,
+        <span class="pl-ent">"failures"</span>: <span class="pl-c1">3</span>,
+        <span class="pl-ent">"status"</span>: <span class="pl-s"><span class="pl-pds">"</span>FAIL<span class="pl-pds">"</span></span>
+      }</pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+          <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="{
+        &quot;instance_count&quot;: 14,
+        &quot;failures&quot;: 3,
+        &quot;status&quot;: &quot;FAIL&quot;
+      }" tabindex="0" role="button">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+          <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+      </svg>
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+          <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+      </svg>
+          </clipboard-copy>
+        </div></div>
+      <p dir="auto">This could then be passed into goss: <code>goss --vars data.json validate</code></p>
+      <p dir="auto">And then validated against:</p>
+      <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">matching</span>:
+        <span class="pl-ent">check_instance_count</span>: <span class="pl-c"><span class="pl-c">#</span> Make sure there is at least one instance</span>
+          <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.instance_count }}</span>
+          <span class="pl-ent">matches</span>:
+            <span class="pl-ent">gt</span>: <span class="pl-c1">0</span>
+
+        <span class="pl-ent">check_failure_count_from_all_instance</span>: <span class="pl-c"><span class="pl-c">#</span> expect no failures</span>
+          <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.failures }}</span>
+          <span class="pl-ent">matches</span>: <span class="pl-c1">0</span>
+
+        <span class="pl-ent">check_status</span>:
+          <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.status }}</span>
+          <span class="pl-ent">matches</span>:
+            - <span class="pl-ent">not</span>: <span class="pl-s">FAIL</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+          <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="matching:
+        check_instance_count: # Make sure there is at least one instance
+          content: {{ .Vars.instance_count }}
+          matches:
+            gt: 0
+
+        check_failure_count_from_all_instance: # expect no failures
+          content: {{ .Vars.failures }}
+          matches: 0
+
+        check_status:
+          content: {{ .Vars.status }}
+          matches:
+            - not: FAIL" tabindex="0" role="button" style="display: none;">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+          <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+      </svg>
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+          <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+      </svg>
+          </clipboard-copy>
+        </div></div>
+      <h4 dir="auto"><a id="user-content-without-templates" class="anchor" aria-hidden="true" href="#without-templates"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Without <a href="#templates">Templates</a>:</h4>
+      <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">matching</span>:
+        <span class="pl-ent">has_substr</span>: <span class="pl-c"><span class="pl-c">#</span> friendly test name</span>
+          <span class="pl-ent">content</span>: <span class="pl-s">some string</span>
+          <span class="pl-ent">matches</span>:
+            <span class="pl-ent">match-regexp</span>: <span class="pl-s">some str</span>
+        <span class="pl-ent">has_2</span>:
+          <span class="pl-ent">content</span>:
+            - <span class="pl-c1">2</span>
+          <span class="pl-ent">matches</span>:
+            <span class="pl-ent">contain-element</span>: <span class="pl-c1">2</span>
+        <span class="pl-ent">has_foo_bar_and_baz</span>:
+          <span class="pl-ent">content</span>:
+            <span class="pl-ent">foo</span>: <span class="pl-s">bar</span>
+            <span class="pl-ent">baz</span>: <span class="pl-s">bing</span>
+          <span class="pl-ent">matches</span>:
+            <span class="pl-ent">and</span>:
+              - <span class="pl-ent">have-key-with-value</span>:
+                  <span class="pl-ent">foo</span>: <span class="pl-s">bar</span>
+              - <span class="pl-ent">have-key</span>: <span class="pl-s">baz</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+          <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="matching:
+        has_substr: # friendly test name
+          content: some string
+          matches:
+            match-regexp: some str
+        has_2:
+          content:
+            - 2
+          matches:
+            contain-element: 2
+        has_foo_bar_and_baz:
+          content:
+            foo: bar
+            baz: bing
+          matches:
+            and:
+              - have-key-with-value:
+                  foo: bar
+              - have-key: baz" tabindex="0" role="button" style="display: none;">
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+          <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+      </svg>
+            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+          <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+      </svg>
+          </clipboard-copy>
+        </div></div>
+
     properties:
       content:
         anyOf:
@@ -319,11 +443,13 @@ definitions:
         type: boolean
         default: true
       versions:
-        type: array
-        items:
-          type: string
-        default:
-        - 2.2.15
+        oneOf:
+          - type: object # matcher
+          - type: array
+            items:
+              type: string
+            default:
+            - 2.2.15
       skip:
         type: boolean
         default: false
@@ -368,20 +494,29 @@ definitions:
         default: true
       # optional attributes
       uid:
-        type: integer
-        default: 65534
+        anyOf:
+          - { "$ref": "#/definitions/matchingTest" }
+          - type: integer
+            default: 65534
+
       gid:
-        type: integer
-        default: 65534
+        anyOf:
+          - { "$ref": "#/definitions/matchingTest" }
+          - type: integer
+            default: 65534
       groups:
-        type: array
-        items:
-          type: string
-        default:
-        - nfsnobody
+        anyOf:
+          - { "$ref": "#/definitions/matchingTest" }
+          - type: array
+            items:
+              type: string
+            default:
+            - nfsnobody
       home:
-        type: string
-        default: /var/lib/nfs
+        anyOf:
+          - { "$ref": "#/definitions/matchingTest" }
+          - type: string
+            default: /var/lib/nfs
       shell:
         type: string
         default: /sbin/nologin
@@ -391,6 +526,7 @@ definitions:
 
 description: "A file describing a series of tests"
 type: "object"
+
 properties:
   process:
     type: object
@@ -587,12 +723,9 @@ properties:
 
   matching:
       type: object
-      description: "Validates specified content against a matcher. Best used with Templates."
-      x-intellij-html-description: |
-        Validates specified content against a matcher. Best used with <a href="#templates">Templates</a>.</p>
-        <h4 dir="auto"><a id="user-content-with-templates" class="anchor" aria-hidden="true" href="#with-templates"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true">
+      description: "Validates mount point attributes."
       additionalProperties:
-        $ref: "#/definitions/matchingTest"
+        $ref: "#/definitions/matchTest"
 
   mount:
       type: object

--- a/docs/goss-json-schema.yaml
+++ b/docs/goss-json-schema.yaml
@@ -1,5 +1,15 @@
-#$schema: "https://json-schema.org/draft/2020-12/schema"
-#$id: "https://github.com/goss-org/goss.json"
+$id: "https://github.com/goss-org/goss/master/docs/goss-json-schema.yaml"
+# Note: this schema was authored using intellij support for Json schema version 7
+# providing coding assistance
+# This schema is based on content from https://github.com/goss-org/goss/blob/master/docs/manual.md
+# It was tested in intellij against https://github.com/goss-org/goss/master/docs/goss.yaml
+# both for completion and code analysis use-cases.
+# Limitations / missing support
+# - meta
+# - title
+# - patterns
+# - advanced matchers
+# - templates
 $schema: http://json-schema.org/draft-07/schema#
 title: "Goss-file-schema"
 definitions:

--- a/docs/goss-json-schema.yaml
+++ b/docs/goss-json-schema.yaml
@@ -6,8 +6,6 @@ $id: "https://github.com/goss-org/goss/master/docs/goss-json-schema.yaml"
 # It was tested in intellij against https://github.com/goss-org/goss/master/docs/goss.yaml
 # both for completion and code analysis use-cases.
 # Limitations / missing support
-# - meta
-# - title
 # - patterns
 # - advanced matchers
 # - templates
@@ -24,8 +22,8 @@ definitions:
   commandTest:
     type: object
     properties:
-      title: { "$ref":"#definitions/title" }
-      meta: { "$ref":"#definitions/meta" }
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       exit-status:
         type: integer
         description: "Validates the exit-status and output of a command"
@@ -55,6 +53,8 @@ definitions:
       - reachable
       - timeout
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       reachable:
         type: boolean
         default: true
@@ -71,6 +71,8 @@ definitions:
     required:
       - resolvable
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       resolvable:
         type: boolean
         default: true
@@ -94,6 +96,8 @@ definitions:
     required:
       - exists
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       exists:
         type: boolean
         default: true
@@ -144,6 +148,8 @@ definitions:
         default: false
   gossfileTest:
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       file:
         type: string
         default: myapp_gossfile.yaml
@@ -154,6 +160,8 @@ definitions:
     required:
       - exists
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       exists:
         type: boolean
         default: true
@@ -172,6 +180,8 @@ definitions:
     required:
       - status
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       status:
         type: integer
         default: 200
@@ -257,6 +267,8 @@ definitions:
     required:
       - exists
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       exists:
         type: boolean
         default: true
@@ -276,120 +288,15 @@ definitions:
     required:
       - value
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       value:
         type: string
         default: Linux
   matchingTest:
-    description: "Validates specified content against a matcher. Best used with Templates."
-    x-intellij-html-description: |
-      <p dir="auto">Validates specified content against a matcher. Best used with <a href="#templates">Templates</a>.</p>
-      <h4 dir="auto"><a id="user-content-with-templates" class="anchor" aria-hidden="true" href="#with-templates"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>With <a href="#templates">Templates</a>:</h4>
-      <p dir="auto">Let's say we have a <code>data.json</code> file that gets generated as part of some testing pipeline:</p>
-      <div class="highlight highlight-source-json notranslate position-relative overflow-auto" dir="auto"><pre>{
-        <span class="pl-ent">"instance_count"</span>: <span class="pl-c1">14</span>,
-        <span class="pl-ent">"failures"</span>: <span class="pl-c1">3</span>,
-        <span class="pl-ent">"status"</span>: <span class="pl-s"><span class="pl-pds">"</span>FAIL<span class="pl-pds">"</span></span>
-      }</pre><div class="zeroclipboard-container position-absolute right-0 top-0">
-          <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="{
-        &quot;instance_count&quot;: 14,
-        &quot;failures&quot;: 3,
-        &quot;status&quot;: &quot;FAIL&quot;
-      }" tabindex="0" role="button">
-            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
-          <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
-      </svg>
-            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
-          <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
-      </svg>
-          </clipboard-copy>
-        </div></div>
-      <p dir="auto">This could then be passed into goss: <code>goss --vars data.json validate</code></p>
-      <p dir="auto">And then validated against:</p>
-      <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">matching</span>:
-        <span class="pl-ent">check_instance_count</span>: <span class="pl-c"><span class="pl-c">#</span> Make sure there is at least one instance</span>
-          <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.instance_count }}</span>
-          <span class="pl-ent">matches</span>:
-            <span class="pl-ent">gt</span>: <span class="pl-c1">0</span>
-
-        <span class="pl-ent">check_failure_count_from_all_instance</span>: <span class="pl-c"><span class="pl-c">#</span> expect no failures</span>
-          <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.failures }}</span>
-          <span class="pl-ent">matches</span>: <span class="pl-c1">0</span>
-
-        <span class="pl-ent">check_status</span>:
-          <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.status }}</span>
-          <span class="pl-ent">matches</span>:
-            - <span class="pl-ent">not</span>: <span class="pl-s">FAIL</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
-          <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="matching:
-        check_instance_count: # Make sure there is at least one instance
-          content: {{ .Vars.instance_count }}
-          matches:
-            gt: 0
-
-        check_failure_count_from_all_instance: # expect no failures
-          content: {{ .Vars.failures }}
-          matches: 0
-
-        check_status:
-          content: {{ .Vars.status }}
-          matches:
-            - not: FAIL" tabindex="0" role="button" style="display: none;">
-            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
-          <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
-      </svg>
-            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
-          <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
-      </svg>
-          </clipboard-copy>
-        </div></div>
-      <h4 dir="auto"><a id="user-content-without-templates" class="anchor" aria-hidden="true" href="#without-templates"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Without <a href="#templates">Templates</a>:</h4>
-      <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">matching</span>:
-        <span class="pl-ent">has_substr</span>: <span class="pl-c"><span class="pl-c">#</span> friendly test name</span>
-          <span class="pl-ent">content</span>: <span class="pl-s">some string</span>
-          <span class="pl-ent">matches</span>:
-            <span class="pl-ent">match-regexp</span>: <span class="pl-s">some str</span>
-        <span class="pl-ent">has_2</span>:
-          <span class="pl-ent">content</span>:
-            - <span class="pl-c1">2</span>
-          <span class="pl-ent">matches</span>:
-            <span class="pl-ent">contain-element</span>: <span class="pl-c1">2</span>
-        <span class="pl-ent">has_foo_bar_and_baz</span>:
-          <span class="pl-ent">content</span>:
-            <span class="pl-ent">foo</span>: <span class="pl-s">bar</span>
-            <span class="pl-ent">baz</span>: <span class="pl-s">bing</span>
-          <span class="pl-ent">matches</span>:
-            <span class="pl-ent">and</span>:
-              - <span class="pl-ent">have-key-with-value</span>:
-                  <span class="pl-ent">foo</span>: <span class="pl-s">bar</span>
-              - <span class="pl-ent">have-key</span>: <span class="pl-s">baz</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
-          <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="matching:
-        has_substr: # friendly test name
-          content: some string
-          matches:
-            match-regexp: some str
-        has_2:
-          content:
-            - 2
-          matches:
-            contain-element: 2
-        has_foo_bar_and_baz:
-          content:
-            foo: bar
-            baz: bing
-          matches:
-            and:
-              - have-key-with-value:
-                  foo: bar
-              - have-key: baz" tabindex="0" role="button" style="display: none;">
-            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
-          <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
-      </svg>
-            <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
-          <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
-      </svg>
-          </clipboard-copy>
-        </div></div>
-
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       content:
         anyOf:
         - type: string
@@ -411,6 +318,8 @@ definitions:
     required:
       - exists
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       exists:
         type: boolean
         default: true
@@ -439,6 +348,8 @@ definitions:
     required:
       - installed
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       installed:
         type: boolean
         default: true
@@ -457,6 +368,8 @@ definitions:
     required:
       - listening
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       listening:
         type: boolean
         default: true
@@ -476,6 +389,8 @@ definitions:
       - running
       - skip
     properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
       enabled:
         type: boolean
         default: true
@@ -489,6 +404,8 @@ definitions:
     required:
       - exists
     properties:
+      title: { "$ref": "#/definitions/title" }
+      meta:  { "$ref": "#/definitions/meta" }
       exists:
         type: boolean
         default: true
@@ -723,8 +640,116 @@ properties:
 
   matching:
       type: object
-      description: "Validates mount point attributes."
-      additionalProperties:
+      description: "Validates specified content against a matcher. Best used with Templates."
+      x-intellij-html-description: |
+        <p dir="auto">Validates specified content against a matcher. Best used with <a href="#templates">Templates</a>.</p>
+        <h4 dir="auto"><a id="user-content-with-templates" class="anchor" aria-hidden="true" href="#with-templates"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>With <a href="#templates">Templates</a>:</h4>
+        <p dir="auto">Let's say we have a <code>data.json</code> file that gets generated as part of some testing pipeline:</p>
+        <div class="highlight highlight-source-json notranslate position-relative overflow-auto" dir="auto"><pre>{
+          <span class="pl-ent">"instance_count"</span>: <span class="pl-c1">14</span>,
+          <span class="pl-ent">"failures"</span>: <span class="pl-c1">3</span>,
+          <span class="pl-ent">"status"</span>: <span class="pl-s"><span class="pl-pds">"</span>FAIL<span class="pl-pds">"</span></span>
+        }</pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+            <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="{
+          &quot;instance_count&quot;: 14,
+          &quot;failures&quot;: 3,
+          &quot;status&quot;: &quot;FAIL&quot;
+        }" tabindex="0" role="button">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+            <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+        </svg>
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+            <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+        </svg>
+            </clipboard-copy>
+          </div></div>
+        <p dir="auto">This could then be passed into goss: <code>goss --vars data.json validate</code></p>
+        <p dir="auto">And then validated against:</p>
+        <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">matching</span>:
+          <span class="pl-ent">check_instance_count</span>: <span class="pl-c"><span class="pl-c">#</span> Make sure there is at least one instance</span>
+            <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.instance_count }}</span>
+            <span class="pl-ent">matches</span>:
+              <span class="pl-ent">gt</span>: <span class="pl-c1">0</span>
+        
+          <span class="pl-ent">check_failure_count_from_all_instance</span>: <span class="pl-c"><span class="pl-c">#</span> expect no failures</span>
+            <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.failures }}</span>
+            <span class="pl-ent">matches</span>: <span class="pl-c1">0</span>
+        
+          <span class="pl-ent">check_status</span>:
+            <span class="pl-ent">content</span>: <span class="pl-s">{{ .Vars.status }}</span>
+            <span class="pl-ent">matches</span>:
+              - <span class="pl-ent">not</span>: <span class="pl-s">FAIL</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+            <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="matching:
+          check_instance_count: # Make sure there is at least one instance
+            content: {{ .Vars.instance_count }}
+            matches:
+              gt: 0
+        
+          check_failure_count_from_all_instance: # expect no failures
+            content: {{ .Vars.failures }}
+            matches: 0
+        
+          check_status:
+            content: {{ .Vars.status }}
+            matches:
+              - not: FAIL" tabindex="0" role="button" style="display: none;">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+            <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+        </svg>
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+            <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+        </svg>
+            </clipboard-copy>
+          </div></div>
+        <h4 dir="auto"><a id="user-content-without-templates" class="anchor" aria-hidden="true" href="#without-templates"><svg class="octicon octicon-link" viewBox="0 0 16 16" version="1.1" width="16" height="16" aria-hidden="true"><path fill-rule="evenodd" d="M7.775 3.275a.75.75 0 001.06 1.06l1.25-1.25a2 2 0 112.83 2.83l-2.5 2.5a2 2 0 01-2.83 0 .75.75 0 00-1.06 1.06 3.5 3.5 0 004.95 0l2.5-2.5a3.5 3.5 0 00-4.95-4.95l-1.25 1.25zm-4.69 9.64a2 2 0 010-2.83l2.5-2.5a2 2 0 012.83 0 .75.75 0 001.06-1.06 3.5 3.5 0 00-4.95 0l-2.5 2.5a3.5 3.5 0 004.95 4.95l1.25-1.25a.75.75 0 00-1.06-1.06l-1.25 1.25a2 2 0 01-2.83 0z"></path></svg></a>Without <a href="#templates">Templates</a>:</h4>
+        <div class="highlight highlight-source-yaml notranslate position-relative overflow-auto" dir="auto"><pre><span class="pl-ent">matching</span>:
+          <span class="pl-ent">has_substr</span>: <span class="pl-c"><span class="pl-c">#</span> friendly test name</span>
+            <span class="pl-ent">content</span>: <span class="pl-s">some string</span>
+            <span class="pl-ent">matches</span>:
+              <span class="pl-ent">match-regexp</span>: <span class="pl-s">some str</span>
+          <span class="pl-ent">has_2</span>:
+            <span class="pl-ent">content</span>:
+              - <span class="pl-c1">2</span>
+            <span class="pl-ent">matches</span>:
+              <span class="pl-ent">contain-element</span>: <span class="pl-c1">2</span>
+          <span class="pl-ent">has_foo_bar_and_baz</span>:
+            <span class="pl-ent">content</span>:
+              <span class="pl-ent">foo</span>: <span class="pl-s">bar</span>
+              <span class="pl-ent">baz</span>: <span class="pl-s">bing</span>
+            <span class="pl-ent">matches</span>:
+              <span class="pl-ent">and</span>:
+                - <span class="pl-ent">have-key-with-value</span>:
+                    <span class="pl-ent">foo</span>: <span class="pl-s">bar</span>
+                - <span class="pl-ent">have-key</span>: <span class="pl-s">baz</span></pre><div class="zeroclipboard-container position-absolute right-0 top-0">
+            <clipboard-copy aria-label="Copy" class="ClipboardButton btn js-clipboard-copy m-2 p-0 tooltipped-no-delay" data-copy-feedback="Copied!" data-tooltip-direction="w" value="matching:
+          has_substr: # friendly test name
+            content: some string
+            matches:
+              match-regexp: some str
+          has_2:
+            content:
+              - 2
+            matches:
+              contain-element: 2
+          has_foo_bar_and_baz:
+            content:
+              foo: bar
+              baz: bing
+            matches:
+              and:
+                - have-key-with-value:
+                    foo: bar
+                - have-key: baz" tabindex="0" role="button" style="display: none;">
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-copy js-clipboard-copy-icon m-2">
+            <path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path>
+        </svg>
+              <svg aria-hidden="true" height="16" viewBox="0 0 16 16" version="1.1" width="16" data-view-component="true" class="octicon octicon-check js-clipboard-check-icon color-fg-success d-none m-2">
+            <path fill-rule="evenodd" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path>
+        </svg>
+            </clipboard-copy>
+          </div></div>
+        
+        additionalProperties:
         $ref: "#/definitions/matchTest"
 
   mount:

--- a/docs/goss.yaml
+++ b/docs/goss.yaml
@@ -1,3 +1,5 @@
+# This sample goss.yaml file is used to test the json schema goss-json-schema.yaml
+
 process:
   mysql:
     exec: "mysql -h"

--- a/docs/goss.yaml
+++ b/docs/goss.yaml
@@ -45,6 +45,9 @@ group:
     exists: true
     skip: false
     gid: 65534
+  nobody:
+    exists: true
+    
 
 http:
   https://www.google.com:
@@ -104,7 +107,12 @@ matching:
                 foo: bar
             - have-key: baz
 
-
+# TODO: sprig syntax fails to accept upper block below
+# https://github.com/goss-org/goss/blob/master/docs/manual.md#examples-2
+#  sping_basic:
+#    content: { { "hello!" | upper | repeat 5 }}
+#                 matches:
+#                 match-regexp: "HELLO!HELLO!HELLO!HELLO!HELLO!"
 
 mount:
   /home:
@@ -122,7 +130,14 @@ package:
     versions:
       - "2.1"
     skip: false
-
+# https://github.com/goss-org/goss/blob/master/README.md#manually-editing-goss-files    
+  kernel:
+    installed: true
+    versions:
+      and:
+        - have-len: 3
+        - not:
+            contain-element: "4.1.0"
 port:
   tcp:22:
     listening: true
@@ -146,3 +161,53 @@ user:
       home: /var/lib/nfs
       shell: /sbin/nologin
       skip: false
+    
+    nobody:
+      exists: true
+      uid:
+        lt: 500
+      groups:
+        consist-of: [nobody]
+    
+    sshd:
+      title: UID must be between 50-100, GID doesn't matter. home is flexible
+      meta:
+        desc: Ensure sshd is enabled and running since it's needed for system management
+        sev: 5
+      exists: true
+      uid:
+        # Validate that UID is between 50 and 100
+        and:
+          gt: 50
+          lt: 100
+      home:
+        # Home can be any of the following
+        or:
+          - /var/empty/sshd
+          - /var/run/sshd
+
+# https://github.com/goss-org/goss/blob/master/README.md#manually-editing-goss-files
+            
+## Matchers
+
+# https://github.com/goss-org/goss/blob/master/docs/manual.md#examples-1
+# TODO: not yet clear whether this is a valid example or should instead be in a matching block
+#example:
+#  content:
+#    - 1.0.1
+#    - 1.9.9
+#  matches:
+#    semver-constraint: ">1.0.0 <2.0.0 !=1.5.0"
+
+## Templates
+    
+# TODO: templates are not valid yaml hence can't be supporter by Json schema 
+#file:
+#  {{- range mkSlice "/etc/passwd" "/etc/group"}}
+#  {{.}}:
+#exists: true
+#mode: "0644"
+#owner: root
+#group: root
+#filetype: file
+#  {{end}}

--- a/docs/goss.yaml
+++ b/docs/goss.yaml
@@ -72,6 +72,40 @@ kernel-param:
   kernel.ostype:
     value: Linux
 
+matching:
+  check_instance_count:
+    content: {{ .Vars.instance_count }}
+    matches:
+      gt: 0
+  check_failure_count_from_all_instance:
+    content: {{ .Vars.failures }}
+    matches: 0
+  check_status:
+    content: {{ .Vars.status }}
+    matches:
+      - not: FAIL
+
+  has_substr: # friendly test name
+    content: some string
+    matches:
+      match-regexp: some str
+    has_2:
+      content:
+        - 2
+      matches:
+        contain-element: 2
+      has_foo_bar_and_baz:
+        content:
+          foo: bar
+          baz: bing
+        matches:
+          and:
+            - have-key-with-value:
+                foo: bar
+            - have-key: baz
+
+
+
 mount:
   /home:
     exists: true

--- a/docs/goss.yaml
+++ b/docs/goss.yaml
@@ -1,0 +1,112 @@
+process:
+  mysql:
+    exec: "mysql -h"
+    exit-status: 0
+
+
+addr:
+  tcp:
+    reachable: true
+    timeout: 500
+    local-address: 127.0.0.1
+
+dns:
+  localhost:
+    addrs:
+      - ::1
+    resolvable: true
+
+file:
+  /ect/password:
+    exists: true
+    mode: "0644"
+    size: 2118
+    owner: root
+    group: root
+    filetype: file
+    contains:
+      - hrll
+    md5: 7c9bb14b3bf178e82c00c2a4398c93cd
+    sha256: 7f78ce27859049f725936f7b52c6e25d774012947d915e7b394402cfceb70c4c
+    sha512: cb71b1940dc879a3688bd502846bff6316dd537bbe917484964fe0f098e9245d80958258dc3bd6297bf42d5bd978cbe2c03d077d4ed45b2b1ed9cd831ceb1bd0
+    linked-to: /usr/sbin/sendmail.sendmail
+    skip: false
+
+
+gossfile:
+  myapplication:
+    file: myapp_gossfile.yaml
+    skip: false
+
+group:
+  nfsnobody:
+    exists: true
+    skip: false
+    gid: 65534
+
+http:
+  https://www.google.com:
+    status: 200
+    allow-insecure: false
+    no-follow-redirects: false
+    timeout: 1000
+    username: ""
+    password: ""
+    ca-file: ""
+    cert-file: ""
+    key-file: ""
+    proxy: ""
+    skip: false
+    method: GET
+
+interface:
+  eth0:
+    exists: true
+    addrs:
+      - " 1"
+    mtu: 1500
+
+kernel-param:
+  kernel.ostype:
+    value: Linux
+
+mount:
+  /home:
+    exists: true
+    opts:
+      - rw
+    source: /dev/mapper/fedora-home
+    filesystem: xfs
+    usage:
+      lt: 95
+
+package:
+  httpd:
+    installed: true
+    versions:
+      - "2.1"
+    skip: false
+
+port:
+  tcp:22:
+    listening: true
+    ip:
+      - "1"
+    skip: false
+
+service:
+  sshd:
+    enabled: true
+    skip: false
+    running: true
+
+user:
+    nfsbody:
+      exists: true
+      uid: 65534
+      gid: 65534
+      groups:
+        - nfsnobody
+      home: /var/lib/nfs
+      shell: /sbin/nologin
+      skip: false


### PR DESCRIPTION

<!-- _Please make sure to review and check all of these items:_ -->
The json schema when configured in IDEs (see updated README.md for Intellij instructions) providers coding assistance for editing and authoring goss.yaml files

including: 
* completion
![image](https://user-images.githubusercontent.com/4748380/209335387-9d2a568e-8af4-4754-99d2-b7e46ee225a7.png)
* inline doc in text or html format for long examples
![image](https://user-images.githubusercontent.com/4748380/209335764-f8eaa9a5-bd84-430b-8ddc-c49ea3ee1656.png)
* inspection such as required properties
![image](https://user-images.githubusercontent.com/4748380/209335831-24f974dd-8561-498e-842c-d4634df3da12.png)


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
* adds a json schema file in yaml format
* addsa a sample goss.yaml file gathering most currently documented examples. Used for testing the json schema

Limitations:
- coverage for matchers is still low. 
- advanced matchers are not yet modeled
- templates likely can't be supported by json schema, and the source document isn't valid yaml
