### PR TITLE
Refine json schema with support for templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,13 @@ curl -H "Accept: application/vnd.goss-rspecish" localhost:8080/healthz
 
 ### Manually editing Goss files
 
-Goss files can be manually edited to improve readability and expresssiveneess of tests.
+Goss files can be manually edited to improve readability and expressiveness of tests.
 
-A [Json draft 7 schema](https://github.com/json-schema-org/json-schema-spec/blob/draft-07/schema.json) available in [docs/goss-json-schema.yaml](./docs/goss-json-schema.yaml) makes it easier to edit simple goss.yaml files in IDEs, providing usual coding assistance such as inline documentation, completion and static analysis.
+A [Json draft 7 schema](https://github.com/json-schema-org/json-schema-spec/blob/draft-07/schema.json) available in [docs/goss-json-schema.yaml](./docs/goss-json-schema.yaml) makes it easier to edit simple goss.yaml files in IDEs, providing usual coding assistance such as inline documentation, completion and static analysis. See [PR 793](https://github.com/goss-org/goss/pull/793) for screenshots.
 
 For example, to configure the Json schema in JetBrains intellij IDEA, follow [documented instructions](https://www.jetbrains.com/help/idea/json.html#ws_json_schema_add_custom), with arguments such as `schema url=https://raw.githubusercontent.com/goss-org/goss/master/docs/goss-json-schema.yaml`, `schema version=Json schema version 7`, `file path pattern=*/goss.yaml`
 
-In addition, Goss files can also be further manually edited (without full json support) to use:
+In addition, Goss files can also be further manually edited (without yet full json support) to use:
 
 * [Patterns](https://github.com/goss-org/goss/blob/master/docs/manual.md#patterns)
 * [Advanced Matchers](https://github.com/goss-org/goss/blob/master/docs/manual.md#advanced-matchers)
@@ -226,6 +226,29 @@ package:
     installed: true
 {{end}}
 ```
+
+Goss.yaml files with templates can still be validated through the Json schema after being rendered using the `goss render` command. See example below  
+
+```bash
+cd docs
+goss --vars ./vars.yaml render > rendered_goss.yaml 
+# proceed with json schema validation of rendered_goss.yaml in your favorite IDE 
+# or in one of the Json schema validator listed in https://json-schema.org/implementations.html
+# The following example is for a Linux AMD64 host 
+curl -LO https://github.com/neilpa/yajsv/releases/download/v1.4.1/yajsv.linux.amd64
+chmod a+x yajsv.linux.amd64 
+sudo mv yajsv.linux.amd64 /usr/sbin/yajsv
+
+yajsv -s goss-json-schema.yaml rendered_goss.yaml
+
+rendered_goss.yaml: fail: process.chrome: skip is required
+rendered_goss.yaml: fail: service.sshd: skip is required
+1 of 1 failed validation
+rendered_goss.yaml: fail: process.chrome: skip is required
+rendered_goss.yaml: fail: service.sshd: skip is required
+```
+
+Full list of available Json schema validators can be found in https://json-schema.org/implementations.html#validator-command%20line
 
 ## Supported resources
 

--- a/docs/goss-json-schema.yaml
+++ b/docs/goss-json-schema.yaml
@@ -3,7 +3,7 @@ $id: "https://github.com/goss-org/goss/master/docs/goss-json-schema.yaml"
 # providing coding assistance
 # This schema is based on content from https://github.com/goss-org/goss/blob/master/docs/manual.md and
 #  and https://github.com/goss-org/goss/blob/master/README.md
-# It was tested in intellij against https://github.com/goss-org/goss/master/docs/goss.yaml
+# It was tested in intellij against https://github.com/goss-org/goss/blob/master/docs/goss.yaml
 # both for completion and code analysis use-cases.
 # Limitations / missing support
 # - patterns

--- a/docs/goss-json-schema.yaml
+++ b/docs/goss-json-schema.yaml
@@ -19,6 +19,25 @@ definitions:
   meta:
     description: meta (arbitrary data) attributes are persisted when adding other resources with goss add
     type: object
+  addrTest:
+    required:
+      - reachable
+      - timeout
+    properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
+      reachable:
+        type: boolean
+        default: true
+      timeout:
+        type: integer
+        default: 500
+        examples:
+          - 500
+          # optional attributes
+      local-address:
+        type: string
+        default: 127.0.0.1
   commandTest:
     type: object
     properties:
@@ -48,25 +67,6 @@ definitions:
         default: false
     required:
       - exit-status
-  addrTest:
-    required:
-      - reachable
-      - timeout
-    properties:
-      title: { "$ref":"#/definitions/title" }
-      meta: { "$ref":"#/definitions/meta" }
-      reachable:
-        type: boolean
-        default: true
-      timeout:
-        type: integer
-        default: 500
-        examples:
-          - 500
-          # optional attributes
-      local-address:
-        type: string
-        default: 127.0.0.1
   dnsTest:
     required:
       - resolvable
@@ -313,7 +313,6 @@ definitions:
           - type: integer
           - type: object
           - type: array
-
   mountTest:
     required:
       - exists
@@ -383,6 +382,19 @@ definitions:
       skip:
         type: boolean
         default: false
+  processTest:
+    required:
+      - running
+      - skip
+    properties:
+      title: { "$ref":"#/definitions/title" }
+      meta: { "$ref":"#/definitions/meta" }
+      running:
+        type: boolean
+        default: true
+      skip:
+        type: boolean
+        default: false
   serviceTest:
     required:
       - enabled
@@ -445,12 +457,6 @@ description: "A file describing a series of tests"
 type: "object"
 
 properties:
-  process:
-    type: object
-    description: "test executing a command"
-    additionalProperties:
-      $ref: "#/definitions/commandTest"
-  
   addr:
       type: object
       description: "Validates if a remote address:port are accessible."
@@ -461,6 +467,12 @@ properties:
             local-address: 127.0.0.1
       additionalProperties:
         $ref: "#/definitions/addrTest"
+
+  command:
+    type: object
+    description: "test executing a command"
+    additionalProperties:
+      $ref: "#/definitions/commandTest"
 
   dns:
       type: object
@@ -786,6 +798,12 @@ properties:
             <span class="pl-ent">skip</span>: <span class="pl-c1">false</span>
       additionalProperties:
         $ref: "#/definitions/portTest"
+
+  process:
+      type: object
+      description: "Validates if a process is running."
+      additionalProperties:
+        $ref: "#/definitions/processTest"
 
   service:
       type: object

--- a/docs/goss.yaml
+++ b/docs/goss.yaml
@@ -26,7 +26,7 @@ dns:
     resolvable: true
 
 file:
-  /ect/password:
+  /ect/password/static:
     exists: true
     mode: "0644"
     size: 2118
@@ -40,7 +40,17 @@ file:
     sha512: cb71b1940dc879a3688bd502846bff6316dd537bbe917484964fe0f098e9245d80958258dc3bd6297bf42d5bd978cbe2c03d077d4ed45b2b1ed9cd831ceb1bd0
     linked-to: /usr/sbin/sendmail.sendmail
     skip: false
-
+# Inline templates are not valid json/yaml that could be validated as-in by json schema
+# Instead, run `goss --vars ./vars.yaml render > rendered_goss.yaml` to render them
+# and apply the schema validation on the rendered file.
+{{- range mkSlice "/etc/passwd" "/etc/group"}}
+  {{.}}:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+{{end}}
 
 gossfile:
   myapplication:
@@ -94,25 +104,30 @@ matching:
     content: {{ .Vars.status }}
     matches:
       - not: FAIL
-
+  example:
+    content:
+      - 1.0.1
+      - 1.9.9
+    matches:
+      semver-constraint: ">1.0.0 <2.0.0 !=1.5.0"
   has_substr: # friendly test name
     content: some string
     matches:
       match-regexp: some str
-    has_2:
-      content:
-        - 2
-      matches:
-        contain-element: 2
-      has_foo_bar_and_baz:
-        content:
-          foo: bar
-          baz: bing
-        matches:
-          and:
-            - have-key-with-value:
-                foo: bar
-            - have-key: baz
+  has_2:
+    content:
+      - 2
+    matches:
+      contain-element: 2
+  has_foo_bar_and_baz:
+    content:
+      foo: bar
+      baz: bing
+    matches:
+      and:
+        - have-key-with-value:
+            foo: bar
+        - have-key: baz
 
 # TODO: sprig syntax fails to accept upper block below
 # https://github.com/goss-org/goss/blob/master/docs/manual.md#examples-2
@@ -201,26 +216,6 @@ user:
 
 # https://github.com/goss-org/goss/blob/master/README.md#manually-editing-goss-files
             
-## Matchers
 
-# https://github.com/goss-org/goss/blob/master/docs/manual.md#examples-1
-# TODO: not yet clear whether this is a valid example or should instead be in a matching block
-#example:
-#  content:
-#    - 1.0.1
-#    - 1.9.9
-#  matches:
-#    semver-constraint: ">1.0.0 <2.0.0 !=1.5.0"
 
-## Templates
-    
-# TODO: templates are not valid yaml hence can't be supporter by Json schema 
-#file:
-#  {{- range mkSlice "/etc/passwd" "/etc/group"}}
-#  {{.}}:
-#exists: true
-#mode: "0644"
-#owner: root
-#group: root
-#filetype: file
-#  {{end}}
+

--- a/docs/goss.yaml
+++ b/docs/goss.yaml
@@ -1,16 +1,23 @@
 # This sample goss.yaml file is used to test the json schema goss-json-schema.yaml
 
-process:
-  mysql:
-    exec: "mysql -h"
-    exit-status: 0
-
-
 addr:
   tcp:
     reachable: true
     timeout: 500
     local-address: 127.0.0.1
+
+command:
+  version:
+    # required attributes
+    exit-status: 0
+    # defaults to hash key
+    exec: "go version"
+    # optional attributes
+    stdout:
+      - go version go1.6 linux/amd64
+    stderr: []
+    timeout: 10000 # in milliseconds
+    skip: false
 
 dns:
   localhost:
@@ -143,6 +150,12 @@ port:
     listening: true
     ip:
       - "1"
+    skip: false
+
+process:
+  chrome:
+    # required attributes
+    running: true
     skip: false
 
 service:

--- a/docs/myapp_gossfile.yaml
+++ b/docs/myapp_gossfile.yaml
@@ -1,0 +1,2 @@
+# This is a sample file referenced by goss.yaml
+# Used for render test and Json schema validation.

--- a/docs/rendered_goss.yaml
+++ b/docs/rendered_goss.yaml
@@ -1,0 +1,169 @@
+file:
+  /ect/password/static:
+    exists: true
+    mode: "0644"
+    size: 2118
+    owner: root
+    group: root
+    linked-to: /usr/sbin/sendmail.sendmail
+    filetype: file
+    contains:
+    - hrll
+    md5: 7c9bb14b3bf178e82c00c2a4398c93cd
+    sha256: 7f78ce27859049f725936f7b52c6e25d774012947d915e7b394402cfceb70c4c
+    sha512: cb71b1940dc879a3688bd502846bff6316dd537bbe917484964fe0f098e9245d80958258dc3bd6297bf42d5bd978cbe2c03d077d4ed45b2b1ed9cd831ceb1bd0
+  /etc/group:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+  /etc/passwd:
+    exists: true
+    mode: "0644"
+    owner: root
+    group: root
+    filetype: file
+    contains: []
+package:
+  httpd:
+    installed: true
+    versions:
+    - "2.1"
+  kernel:
+    installed: true
+    versions:
+      and:
+      - have-len: 3
+      - not:
+          contain-element: 4.1.0
+addr:
+  tcp:
+    local-address: 127.0.0.1
+    reachable: true
+    timeout: 500
+port:
+  tcp:22:
+    listening: true
+    ip:
+    - "1"
+service:
+  sshd:
+    enabled: true
+    running: true
+user:
+  nfsbody:
+    exists: true
+    uid: 65534
+    gid: 65534
+    groups:
+    - nfsnobody
+    home: /var/lib/nfs
+    shell: /sbin/nologin
+  nobody:
+    exists: true
+    uid:
+      lt: 500
+    groups:
+      consist-of:
+      - nobody
+  sshd:
+    title: UID must be between 50-100, GID doesn't matter. home is flexible
+    meta:
+      desc: Ensure sshd is enabled and running since it's needed for system management
+      sev: 5
+    exists: true
+    uid:
+      and:
+        gt: 50
+        lt: 100
+    home:
+      or:
+      - /var/empty/sshd
+      - /var/run/sshd
+group:
+  nfsnobody:
+    exists: true
+    gid: 65534
+  nobody:
+    exists: true
+command:
+  version:
+    exec: go version
+    exit-status: 0
+    stdout:
+    - go version go1.6 linux/amd64
+    stderr: []
+    timeout: 10000
+dns:
+  localhost:
+    resolvable: true
+    addrs:
+    - ::1
+    timeout: 0
+process:
+  chrome:
+    running: true
+kernel-param:
+  kernel.ostype:
+    value: Linux
+mount:
+  /home:
+    exists: true
+    opts:
+    - rw
+    source: /dev/mapper/fedora-home
+    filesystem: xfs
+    usage:
+      lt: 95
+interface:
+  eth0:
+    exists: true
+    addrs:
+    - ' 1'
+    mtu: 1500
+http:
+  https://www.google.com:
+    method: GET
+    status: 200
+    allow-insecure: false
+    no-follow-redirects: false
+    timeout: 1000
+    body: []
+matching:
+  check_failure_count_from_all_instance:
+    content: 0
+    matches: 0
+  check_instance_count:
+    content: 1
+    matches:
+      gt: 0
+  check_status:
+    content: PASS
+    matches:
+    - not: FAIL
+  example:
+    content:
+    - 1.0.1
+    - 1.9.9
+    matches:
+      semver-constraint: '>1.0.0 <2.0.0 !=1.5.0'
+  has_2:
+    content:
+    - 2
+    matches:
+      contain-element: 2
+  has_foo_bar_and_baz:
+    content:
+      baz: bing
+      foo: bar
+    matches:
+      and:
+      - have-key-with-value:
+          foo: bar
+      - have-key: baz
+  has_substr:
+    content: some string
+    matches:
+      match-regexp: some str

--- a/docs/vars.yaml
+++ b/docs/vars.yaml
@@ -1,0 +1,5 @@
+# Sample vars file used in goss.yaml#matching
+# Used for render test and Json schema validation.
+instance_count: 1
+failures: 0
+status: "PASS"


### PR DESCRIPTION
Document how Schema validation can still be applied for goss.yaml files using inline templates, by using render preprocessing

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change

Doc update

Would be nice to add some automated tests by using a json schema validator, e.g. one available from https://json-schema.org/implementations.html such as https://github.com/santhosh-tekuri/jsonschema yet its yaml support is pending, see https://github.com/santhosh-tekuri/jsonschema/pull/52
