### PR TITLE
add gossboss to README "community" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ package:
 * [goss-fpm-files](https://github.com/deanwilson/unixdaemon-fpm-cookery-recipes) - Might be useful for building goss system packages.
 * [molecule](https://github.com/metacloud/molecule) - Automated testing for Ansible roles, with native Goss support.
 * [packer-provisioner-goss](https://github.com/YaleUniversity/packer-provisioner-goss) - A packer plugin to run Goss as a provision step.
+* [gossboss](https://github.com/mdb/gossboss) - Collect and view aggregated Goss test results from multiple remote Goss servers.
 
 ## Limitations
 


### PR DESCRIPTION
👋 Thanks for your work on `goss`. This adds mention of [gossboss](https://github.com/mdb/gossboss) to the `README`'s 
"Community Contributions" section. Is that worthwhile?