### PR TITLE
fix issue 443 mount.vfs-opts

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -683,6 +683,11 @@ mount:
     opts:
     - rw
     - relatime
+    # This maps to the per-superblock options, see:
+    # https://man7.org/linux/man-pages/man5/proc.5.html
+    # https://man7.org/linux/man-pages/man2/mount.2.html
+    vfs-opts:
+    - rw
     source: /dev/mapper/fedora-home
     filesystem: xfs
     usage: #% of blocks used in this mountpoint

--- a/integration-tests/goss/alpine3/goss-expected.yaml
+++ b/integration-tests/goss/alpine3/goss-expected.yaml
@@ -144,6 +144,8 @@ mount:
     opts:
     - rw
     - nosuid
+    vfs-opts:
+    - rw
     source: tmpfs
     filesystem: tmpfs
 http:

--- a/integration-tests/goss/centos7/goss-expected.yaml
+++ b/integration-tests/goss/centos7/goss-expected.yaml
@@ -150,6 +150,8 @@ mount:
     opts:
     - rw
     - nosuid
+    vfs-opts:
+    - rw
     source: tmpfs
     filesystem: tmpfs
 http:

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -172,6 +172,7 @@ mount:
     opts:
     - rw
     - nosuid
+    vfs-opts:
     - mode=755
     source: tmpfs
     filesystem: tmpfs

--- a/integration-tests/goss/trusty/goss-expected.yaml
+++ b/integration-tests/goss/trusty/goss-expected.yaml
@@ -150,6 +150,8 @@ mount:
     opts:
     - rw
     - nosuid
+    vfs-opts:
+    - rw
     source: tmpfs
     filesystem: tmpfs
 http:

--- a/integration-tests/goss/wheezy/goss-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-expected.yaml
@@ -150,6 +150,8 @@ mount:
     opts:
     - rw
     - nosuid
+    vfs-opts:
+    - rw
     source: tmpfs
     filesystem: tmpfs
 http:

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -34,7 +34,7 @@ fi
 # Setup local httbin
 # FIXME: this is a quick hack to fix intermittent CI issues
 network=goss-test
-docker network create --driver bridge $network
+docker network create --driver bridge  --subnet '172.19.0.0/16' $network
 docker run -d --name httpbin --network $network kennethreitz/httpbin
 opts=(--env OS=$os --cap-add SYS_ADMIN -v "$PWD/goss:/goss" -d --name "$container_name" --security-opt seccomp:unconfined --security-opt label:disable)
 id=$(docker run "${opts[@]}" --network $network "aelsabbahy/goss_$os" /sbin/init)
@@ -48,23 +48,23 @@ out=$(docker_exec "/goss/$os/goss-linux-$arch" --vars "/goss/vars.yaml" --vars-i
 echo "$out"
 
 if [[ $os == "arch" ]]; then
-    egrep -q 'Count: 99, Failed: 0, Skipped: 3' <<<"$out"
+    egrep -q 'Count: 100, Failed: 0, Skipped: 3' <<<"$out"
 else
-    egrep -q 'Count: 120, Failed: 0, Skipped: 5' <<<"$out"
+    egrep -q 'Count: 121, Failed: 0, Skipped: 5' <<<"$out"
 fi
 
 if [[ ! $os == "arch" ]]; then
   docker_exec /goss/generate_goss.sh "$os" "$arch"
 
-  #docker exec $container_name bash -c "cp /goss/${os}/goss-generated-$arch.yaml /goss/${os}/goss-expected.yaml"
+  # docker exec $container_name bash -c "cp /goss/${os}/goss-generated-$arch.yaml /goss/${os}/goss-expected.yaml"
   docker_exec diff -wu "/goss/${os}/goss-expected.yaml" "/goss/${os}/goss-generated-$arch.yaml"
 
-  #docker exec $container_name bash -c "cp /goss/${os}/goss-aa-generated-$arch.yaml /goss/${os}/goss-aa-expected.yaml"
+  # docker exec $container_name bash -c "cp /goss/${os}/goss-aa-generated-$arch.yaml /goss/${os}/goss-aa-expected.yaml"
   docker_exec diff -wu "/goss/${os}/goss-aa-expected.yaml" "/goss/${os}/goss-aa-generated-$arch.yaml"
 
   docker_exec /goss/generate_goss.sh "$os" "$arch" -q
 
-  #docker exec $container_name bash -c "cp /goss/${os}/goss-generated-$arch.yaml /goss/${os}/goss-expected-q.yaml"
+  # docker exec $container_name bash -c "cp /goss/${os}/goss-generated-$arch.yaml /goss/${os}/goss-expected-q.yaml"
   docker_exec diff -wu "/goss/${os}/goss-expected-q.yaml" "/goss/${os}/goss-generated-$arch.yaml"
 fi
 

--- a/resource/mount.go
+++ b/resource/mount.go
@@ -14,6 +14,7 @@ type Mount struct {
 	MountPoint string  `json:"mountpoint,omitempty" yaml:"mountpoint,omitempty"`
 	Exists     matcher `json:"exists" yaml:"exists"`
 	Opts       matcher `json:"opts,omitempty" yaml:"opts,omitempty"`
+	VfsOpts    matcher `json:"vfs-opts,omitempty" yaml:"vfs-opts,omitempty"`
 	Source     matcher `json:"source,omitempty" yaml:"source,omitempty"`
 	Filesystem matcher `json:"filesystem,omitempty" yaml:"filesystem,omitempty"`
 	Skip       bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
@@ -62,6 +63,9 @@ func (m *Mount) Validate(sys *system.System) []TestResult {
 	if m.Opts != nil {
 		results = append(results, ValidateValue(m, "opts", m.Opts, sysMount.Opts, skip))
 	}
+	if m.VfsOpts != nil {
+		results = append(results, ValidateValue(m, "vfs-opts", m.VfsOpts, sysMount.VfsOpts, skip))
+	}
 	if m.Source != nil {
 		results = append(results, ValidateValue(m, "source", m.Source, sysMount.Source, skip))
 	}
@@ -84,6 +88,11 @@ func NewMount(sysMount system.Mount, config util.Config) (*Mount, error) {
 	if !contains(config.IgnoreList, "opts") {
 		if opts, err := sysMount.Opts(); err == nil {
 			m.Opts = opts
+		}
+	}
+	if !contains(config.IgnoreList, "vfs-opts") {
+		if vfsOpts, err := sysMount.VfsOpts(); err == nil {
+			m.VfsOpts = vfsOpts
 		}
 	}
 	if !contains(config.IgnoreList, "source") {

--- a/system/mount.go
+++ b/system/mount.go
@@ -13,6 +13,7 @@ type Mount interface {
 	MountPoint() string
 	Exists() (bool, error)
 	Opts() ([]string, error)
+	VfsOpts() ([]string, error)
 	Source() (string, error)
 	Filesystem() (string, error)
 	Usage() (int, error)
@@ -78,9 +79,17 @@ func (m *DefMount) Opts() ([]string, error) {
 	if err := m.setup(); err != nil {
 		return nil, err
 	}
-	allOpts := splitMountInfo(strings.Join([]string{m.mountInfo.Options, m.mountInfo.VFSOptions}, ","))
+	allOpts := splitMountInfo(m.mountInfo.Options)
 
 	return lo.Uniq(allOpts), nil
+}
+
+func (m *DefMount) VfsOpts() ([]string, error) {
+	if err := m.setup(); err != nil {
+		return nil, err
+	}
+	opts := splitMountInfo(m.mountInfo.VFSOptions)
+	return opts, nil
 }
 
 func (m *DefMount) Source() (string, error) {


### PR DESCRIPTION
FIXED: split opts and vfs-opts to address complex mount tests (closes… #443)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Adds vfs-opts to mount options. This addresses a regression with v0.4.0-rc1