### PR TITLE
Fix release-build.sh for macOS

### DIFF
--- a/release-build.sh
+++ b/release-build.sh
@@ -28,4 +28,12 @@ GOOS="${os}" GOARCH="${arch}" CGO_ENABLED=0 go build \
 
 chmod +x "${output}"
 
-(cd "$output_dir" && sha256sum "${output_fname}" > "${output_fname}.sha256")
+function __sha256sum {
+  if [[ "$OSTYPE" == "darwin"* ]]; then
+    shasum -a 256 "$1"
+  else
+    sha256sum "$1"
+  fi
+}
+
+(cd "$output_dir" && __sha256sum "${output_fname}" > "${output_fname}.sha256")


### PR DESCRIPTION
##### Checklist
- [x] `make test-all` (UNIX) passes. CI will also test this

### Description of change
This pull request fixes release-build.sh to run "make build" on macOS.

On macOS, "make build" failed because there is no sha256sum command in the default environment.
```
% sw_vers 
ProductName:		macOS
ProductVersion:		13.5
BuildVersion:		22G74
% make build    
./release-build.sh alpha-darwin-amd64
./release-build.sh: line 39: sha256sum: command not found
make: *** [release/goss-alpha-darwin-amd64] Error 127
```