### PR TITLE
Rename binaries to strip '-alpha' in .travis.yml and Makefile (Related: #671)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,8 @@ deploy:
     - release/goss-linux-arm.sha256
     - release/goss-linux-arm64
     - release/goss-linux-arm64.sha256
-    - release/goss-alpha-windows-amd64.exe
-    - release/goss-alpha-windows-amd64.exe.sha256
+    - release/goss-windows-amd64.exe
+    - release/goss-windows-amd64.exe.sha256
     - extras/dgoss/dgoss
     - extras/dgoss/dgoss.sha256
   skip_cleanup: true

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ release:
 	$(MAKE) clean
 	$(MAKE) build
 
-build: release/goss-alpha-darwin-amd64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-linux-arm64 release/goss-alpha-windows-amd64
+build: release/goss-darwin-amd64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-linux-arm64 release/goss-windows-amd64
 
 gen:
 	$(info INFO: Starting build $@)


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this


### Description of change
This pull request renames binaries for macOS and Windows to strip '-alpha'. ( refer to #671 )
We hope this will resolve the lack of macOS binary in the latest releases (v0.4.0-rc.2).