### PR TITLE
Fix run-validate-tests.sh to run "make test-int-validate-darwin-amd64" on local Mac

### DIFF
--- a/integration-tests/run-validate-tests.sh
+++ b/integration-tests/run-validate-tests.sh
@@ -21,14 +21,13 @@ fi
 repo_root="$(git rev-parse --show-toplevel)"
 export GOSS_BINARY="${repo_root}/release/goss-${platform_spec}"
 log_info "Using: '${GOSS_BINARY}', cwd: '$(pwd)', os: ${os}"
-readarray -t goss_test_files < <(find integration-tests -type f -name "*.goss.yaml" | grep "${os}" | sort | uniq)
 
 export GOSS_USE_ALPHA=1
-for file in "${goss_test_files[@]}"; do
+for file in `find integration-tests -type f -name "*.goss.yaml" | grep "${os}" | sort | uniq`; do
   args=(
     "-g=${file}"
     "validate"
   )
-  log_action -e "\nTesting \`${GOSS_BINARY} ${args[*]}\` ...\n"
+  log_action "\nTesting \`${GOSS_BINARY} ${args[*]}\` ...\n"
   "${GOSS_BINARY}" "${args[@]}"
 done


### PR DESCRIPTION
##### Checklist
- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)

### Description of change
This pull request fixes run-validate-tests.sh to run "make test-int-validate-darwin-amd64" on local Mac.

On macOS, "make test-int-validate-darwin-amd64" failed because there is no readarray command in the default environment.
```
% sw_vers 
ProductName:		macOS
ProductVersion:		13.5
BuildVersion:		22G74
% make test-int-validate-darwin-amd64
INFO: Starting build test-int-validate-darwin-amd64
./integration-tests/run-validate-tests.sh darwin-amd64
Using: '/Users/USERNAME/go/src/github.com/goss-org/goss/release/goss-darwin-amd64', cwd: '/Users/USERNAME/go/src/github.com/goss-org/goss', os: darwin
./integration-tests/run-validate-tests.sh: line 24: readarray: command not found
panic: uncaught error
Traceback (most recent call first):
  at ./integration-tests/run-validate-tests.sh:24 in main()
readarray -t goss_test_files < <(find integration-tests -type f -name "*.goss.yaml" | grep "${os}" | sort | uniq) exited 127
make: *** [test-int-validate-darwin-amd64] Error 127
% panic: uncaught error
Traceback (most recent call first):
  at ./integration-tests/run-validate-tests.sh:24 in main()
uniq exited 141
```