### PR TITLE
Added: warning when duplicate keys cause tests to be overwritten

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -75,7 +75,7 @@ func main() {
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   "log-level, loglevel, L, l",
-			Value:  "FATAL",
+			Value:  "INFO",
 			Usage:  "Goss log verbosity level",
 			EnvVar: "GOSS_LOGLEVEL",
 		},

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -229,13 +229,12 @@ service:
 * `--endpoint <value>`, `-e <value>` - Endpoint to expose (default: `/healthz`)
 * `--format`, `-f` - output format, same as [validate](#validate-v---validate-the-system)
 * `--listen-addr [ip]:port`, `-l [ip]:port` - Address to listen on (default: `:8080`)
-* `--loglevel level`, `-L level` - Goss logging verbosity level (default: `INFO`). `level` can be one of `TRACE | DEBUG | INFO | WARN | ERROR | FATAL`. Lower levels of tracing include all upper levels traces also (ie. INFO include WARN, ERROR and FATAL outputs).
-  * `TRACE` - Print details for each check, successful or not and all incoming healthchecks
-  * `DEBUG` - Print details of summary response to healthchecks including remote IP address, return code and full body
-  * `INFO` - Print summary when all checks run OK
-  * `WARN` - Print summary and corresponding checks when encountering some failures
-  * `ERROR` - Not used for now (will not print anything)
-  * `FATAL` - Not used for now (will not print anything)
+* `--loglevel level`, `-L level` - Goss logging verbosity level (default: `INFO`). `level` can be one of `TRACE | DEBUG | INFO | WARN | ERROR`. Lower levels of tracing include all upper levels traces also (ie. INFO include WARN and ERROR).
+  * `ERROR` - Critical errors that halt goss or significantly affect its functionality, requiring immediate intervention.
+  * `WARN` - Non-critical issues that may require attention, such as overwritten keys or deprecated features.
+  * `INFO` - General operational messages, useful for tasks where a more structured output is needed (e.g. goss serve).
+  * `DEBUG` - Information useful for the goss user to debug.
+  * `TRACE` - Detailed internal system activities useful for goss developers to debug.
 * `--max-concurrent` - Max number of tests to run concurrently
 
 #### Example:

--- a/goss_config.go
+++ b/goss_config.go
@@ -1,6 +1,7 @@
 package goss
 
 import (
+	"log"
 	"reflect"
 
 	"github.com/goss-org/goss/resource"
@@ -50,65 +51,73 @@ func NewGossConfig() *GossConfig {
 // will be overwritten with the ones in g2
 func (c *GossConfig) Merge(g2 GossConfig) {
 	for k, v := range g2.Files {
-		c.Files[k] = v
+		mergeType(c.Files, "file", k, v)
 	}
 
 	for k, v := range g2.Packages {
-		c.Packages[k] = v
+		mergeType(c.Packages, "package", k, v)
 	}
 
 	for k, v := range g2.Addrs {
-		c.Addrs[k] = v
+		mergeType(c.Addrs, "addr", k, v)
 	}
 
 	for k, v := range g2.Ports {
-		c.Ports[k] = v
+		mergeType(c.Ports, "port", k, v)
 	}
 
 	for k, v := range g2.Services {
-		c.Services[k] = v
+		mergeType(c.Services, "service", k, v)
 	}
 
 	for k, v := range g2.Users {
-		c.Users[k] = v
+		mergeType(c.Users, "user", k, v)
 	}
 
 	for k, v := range g2.Groups {
-		c.Groups[k] = v
+		mergeType(c.Groups, "group", k, v)
 	}
 
 	for k, v := range g2.Commands {
-		c.Commands[k] = v
+		mergeType(c.Commands, "command", k, v)
 	}
 
 	for k, v := range g2.DNS {
-		c.DNS[k] = v
+		mergeType(c.DNS, "dns", k, v)
 	}
 
 	for k, v := range g2.Processes {
-		c.Processes[k] = v
+		mergeType(c.Processes, "process", k, v)
 	}
 
 	for k, v := range g2.KernelParams {
-		c.KernelParams[k] = v
+		mergeType(c.KernelParams, "kernel-param", k, v)
 	}
 
 	for k, v := range g2.Mounts {
-		c.Mounts[k] = v
+		mergeType(c.Mounts, "mount", k, v)
 	}
 
 	for k, v := range g2.Interfaces {
-		c.Interfaces[k] = v
+		mergeType(c.Interfaces, "interface", k, v)
 	}
 
 	for k, v := range g2.HTTPs {
-		c.HTTPs[k] = v
+		mergeType(c.HTTPs, "http", k, v)
 	}
 
 	for k, v := range g2.Matchings {
-		c.Matchings[k] = v
+		mergeType(c.Matchings, "matching", k, v)
 	}
 }
+
+func mergeType[V any](m map[string]V, t, k string, v V) {
+		if _, ok := m[k]; ok {
+			log.Printf("[WARN] Duplicate key detected: '%s: %s'. The value from a later-loaded goss file has overwritten the previous value.", t, k)
+		}
+		m[k] = v
+}
+
 
 func (c *GossConfig) Resources() []resource.Resource {
 	var tests []resource.Resource

--- a/logs.go
+++ b/logs.go
@@ -14,8 +14,8 @@ import (
 
 func setLogLevel(c *util.Config) error {
 	filter := &logutils.LevelFilter{
-		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"},
-		MinLevel: logutils.LogLevel("WARN"),
+		Levels:   []logutils.LogLevel{"TRACE", "DEBUG", "INFO", "WARN", "ERROR"},
+		MinLevel: logutils.LogLevel("INFO"),
 		Writer:   os.Stderr,
 	}
 	log.SetFlags(0) // Turn off standard timestamp flags

--- a/outputs/json.go
+++ b/outputs/json.go
@@ -48,7 +48,7 @@ func (r Json) Output(w io.Writer, results <-chan []resource.TestResult,
 			}
 			if testResult.Result == resource.FAIL {
 				failed++
-				logTrace("WARN", "FAIL", testResult, true)
+				logTrace("TRACE", "FAIL", testResult, true)
 			} else {
 				logTrace("TRACE", "SUCCESS", testResult, true)
 			}
@@ -88,11 +88,11 @@ func (r Json) Output(w io.Writer, results <-chan []resource.TestResult,
 	fmt.Fprintln(w, resstr)
 
 	if failed > 0 {
-		log.Printf("[WARN] FAIL SUMMARY: %s", resstr)
+		log.Printf("[DEBUG] FAIL SUMMARY: %s", resstr)
 		return 1
 	}
 
-	log.Printf("[INFO] OK SUMMARY: %s", resstr)
+	log.Printf("[DEBUG] OK SUMMARY: %s", resstr)
 	return 0
 }
 

--- a/outputs/rspecish.go
+++ b/outputs/rspecish.go
@@ -50,7 +50,7 @@ func (r Rspecish) Output(w io.Writer, results <-chan []resource.TestResult,
 				failedOrSkippedGroup = append(failedOrSkippedGroup, testResult)
 				skipped++
 			case resource.FAIL:
-				logTrace("WARN", "FAIL", testResult, false)
+				logTrace("TRACE", "FAIL", testResult, false)
 				fmt.Fprintf(w, red("F"))
 				failedOrSkippedGroup = append(failedOrSkippedGroup, testResult)
 				failed++
@@ -71,9 +71,9 @@ func (r Rspecish) Output(w io.Writer, results <-chan []resource.TestResult,
 	fmt.Fprint(w, outstr)
 	resstr := strings.ReplaceAll(outstr, "\n", " ")
 	if failed > 0 {
-		log.Printf("[WARN] FAIL SUMMARY: %s", resstr)
+		log.Printf("[DEBUG] FAIL SUMMARY: %s", resstr)
 		return 1
 	}
-	log.Printf("[INFO] OK SUMMARY: %s", resstr)
+	log.Printf("[DEBUG] OK SUMMARY: %s", resstr)
 	return 0
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Prints out warning messages when overlapping keys are detected, for example:

goss.yaml:
```yaml
command:
  example_test:
    exec: echo "hi"
    exit-status: 0
    stdout:
    - hi
    stderr: ""
    timeout: 10000
gossfile:
  goss_embed.yaml: {}
```

goss_embed.yaml:
```yaml
command:
  example_test:
    exec: echo "bye"
    exit-status: 0
    stdout:
    - bye
    timeout: 10000
```

```
$ goss -l warn v
2023-09-16T20:36:48Z [WARN] Duplicate key detected: 'command: example_test'. The value from a later-loaded goss file has overwritten the previous value.
..

Total Duration: 0.002s
Count: 2, Failed: 0, Skipped: 0
```

Same with render:
```
$ goss -l warn render > /dev/null
2023/09/16 13:37:07 [WARN] Duplicate key detected: 'command: example_test'. The value from a later-loaded goss file has overwritten the previous value.
```

This warning is printed for both failing and passing tests, essentially it is informing the user that the tests were overwritten.. which may or may not be desired.

As a consequence of this change, I moved some existing log levels around to match what I would expect as a user:

  * `TRACE` - Detailed internal system activities useful for goss developers to debug.
  * `DEBUG` - Information useful for the goss user to debug.
  * `INFO` - General operational messages, useful for tasks where a more structured output is needed (e.g. `goss serve`).
  * `WARN` - Non-critical issues that may require attention, such as overwritten keys or deprecated features.

closes #743

### Questions

1. Given the above classification, should the default log level be set to INFO? Users who find it noisy can do `-l warn` or `-l error`