### PR TITLE
Fixed: Return the error when a command fails to start

### DIFF
--- a/util/command.go
+++ b/util/command.go
@@ -36,7 +36,7 @@ func (c *Command) Run() error {
 
 	if err := c.Cmd.Start(); err != nil {
 		c.Err = err
-		//log.Fatalf("Cmd.Start: %v")
+		return c.Err
 	}
 
 	if err := c.Cmd.Wait(); err != nil {
@@ -44,7 +44,6 @@ func (c *Command) Run() error {
 		if exiterr, ok := err.(*exec.ExitError); ok {
 			if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
 				c.Status = status.ExitStatus()
-				//log.Printf("Exit Status: %d", status.ExitStatus())
 			}
 		}
 	} else {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Better reporting of error when process fails to start.