### PR TITLE
"socket" as one more valid filetype for "file" testing

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -540,7 +540,7 @@ dns:
 ```
 
 ### file
-Validates the state of a file, directory, or symbolic link
+Validates the state of a file, directory, socket, or symbolic link
 
 ```yaml
 file:
@@ -554,7 +554,7 @@ file:
     size: 2118 # in bytes
     owner: root
     group: root
-    filetype: file # file, symlink, directory
+    filetype: file # file, symlink, directory, socket
     contents: [] # Check file content for these patterns
     md5: 7c9bb14b3bf178e82c00c2a4398c93cd # md5 checksum of file
     # A stronger checksum alternatives to md5 (recommended)
@@ -564,7 +564,7 @@ file:
     # required attributes
     exists: true
     # optional attributes
-    filetype: symlink # file, symlink, directory
+    filetype: symlink # file, symlink, directory, socket
     linked-to: /usr/sbin/sendmail.sendmail
     skip: false
 ```


### PR DESCRIPTION
##### Checklist

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

### Description of change

Some files can be sockets. Goss detects already socket files correctly with filetype `socket`.

