### PR TITLE
fix outcome label in goss_tests_run_outcomes_total

### DIFF
--- a/ci/go-test.sh
+++ b/ci/go-test.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 command -v go
 
-go test -coverpkg=./... ./... -skip '^TestPrometheus' -coverprofile="c.out"
+go test -coverpkg=./... ./... -coverprofile="c.out"
 
 sed 's|github.com/goss-org/goss/||' <"c.out" >"c.out.tmp"
 

--- a/outputs/prometheus_test.go
+++ b/outputs/prometheus_test.go
@@ -2,6 +2,7 @@ package outputs
 
 import (
 	"bytes"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -12,50 +13,474 @@ import (
 )
 
 func TestPrometheusOutput(t *testing.T) {
-	buf := &bytes.Buffer{}
-	outputer := &Prometheus{}
-	injectedResults := []resource.TestResult{
-		{
-			ResourceType: "Command",
-			Duration:     10 * time.Millisecond,
-			Result:       resource.SUCCESS,
+	testCases := map[string]struct {
+		results         []resource.TestResult
+		expectedMetrics []string
+	}{
+		"all-success-single-type": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 20`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 2`,
+				`goss_tests_run_duration_milliseconds{outcome="pass"}`,
+				`goss_tests_run_outcomes_total{outcome="pass"} 1`,
+			},
 		},
-		{
-			ResourceType: "Command",
-			Duration:     10 * time.Millisecond,
-			Result:       resource.SUCCESS,
+		"all-skip-single-type": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 20`,
+				`goss_tests_outcomes_total{outcome="skip",type="command"} 2`,
+				`goss_tests_run_duration_milliseconds{outcome="skip"}`,
+				`goss_tests_run_outcomes_total{outcome="skip"} 1`,
+			},
 		},
-		{
-			ResourceType: "Command",
-			Duration:     10 * time.Millisecond,
-			Result:       resource.FAIL,
+		"all-fail-single-type": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 20`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 2`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
 		},
-		{
-			ResourceType: "File",
-			Duration:     10 * time.Millisecond,
-			Result:       resource.SKIP,
+		"all-unknown-single-type": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="command"} 20`,
+				`goss_tests_outcomes_total{outcome="unknown",type="command"} 2`,
+				`goss_tests_run_duration_milliseconds{outcome="unknown"}`,
+				`goss_tests_run_outcomes_total{outcome="unknown"} 1`,
+			},
+		},
+		"all-success-multiple-types": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+				{
+					ResourceType: "File",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="file"} 10`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="pass",type="file"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="pass"}`,
+				`goss_tests_run_outcomes_total{outcome="pass"} 1`,
+			},
+		},
+		"various-results-single-type": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="skip",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="unknown",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
+		},
+		"various-results-multiple-types": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+				{
+					ResourceType: "File",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+				{
+					ResourceType: "File",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="file"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="file"} 10`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="skip",type="file"} 1`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="unknown",type="file"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
+		},
+		"unknown-skip": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="skip",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="unknown",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="unknown"}`,
+				`goss_tests_run_outcomes_total{outcome="unknown"} 1`,
+			},
+		},
+		"unknown-fail": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="unknown",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
+		},
+		"unknown-success": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="unknown",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="unknown"}`,
+				`goss_tests_run_outcomes_total{outcome="unknown"} 1`,
+			},
+		},
+		"skip-unknown": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="skip",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="unknown",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="unknown"}`,
+				`goss_tests_run_outcomes_total{outcome="unknown"} 1`,
+			},
+		},
+		"skip-fail": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="skip",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
+		},
+		"skip-success": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="skip",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="pass"}`,
+				`goss_tests_run_outcomes_total{outcome="pass"} 1`,
+			},
+		},
+		"fail-unknown": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="unknown",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
+		},
+		"fail-skip": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="skip",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
+		},
+		"fail-success": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
+		},
+		"success-unknown": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.UNKNOWN,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="unknown",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="unknown",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="unknown"}`,
+				`goss_tests_run_outcomes_total{outcome="unknown"} 1`,
+			},
+		},
+		"success-skip": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SKIP,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="skip",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="pass"}`,
+				`goss_tests_run_outcomes_total{outcome="pass"} 1`,
+			},
+		},
+		"success-fail": {
+			results: []resource.TestResult{
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.SUCCESS,
+				},
+				{
+					ResourceType: "Command",
+					Duration:     10 * time.Millisecond,
+					Result:       resource.FAIL,
+				},
+			},
+			expectedMetrics: []string{
+				`goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 10`,
+				`goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`,
+				`goss_tests_outcomes_total{outcome="pass",type="command"} 1`,
+				`goss_tests_outcomes_total{outcome="fail",type="command"} 1`,
+				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
+				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
+			},
+		},
+		"no-results": {
+			results: []resource.TestResult{},
+			expectedMetrics: []string{
+				`goss_tests_run_duration_milliseconds{outcome="unknown"}`,
+				`goss_tests_run_outcomes_total{outcome="unknown"} 1`,
+			},
 		},
 	}
 
-	exitCode := outputer.Output(buf, makeResults(injectedResults...), util.OutputConfig{})
+	for name, testCase := range testCases {
+		t.Run(name, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			outputer := &Prometheus{}
 
-	assert.Equal(t, 0, exitCode)
-	output := buf.String()
-	t.Logf(output)
-	assert.Contains(t, output, `goss_tests_outcomes_duration_milliseconds{outcome="pass",type="command"} 20`)
-	assert.Contains(t, output, `goss_tests_outcomes_duration_milliseconds{outcome="fail",type="command"} 10`)
-	assert.Contains(t, output, `goss_tests_outcomes_duration_milliseconds{outcome="skip",type="command"} 0`)
-	assert.Contains(t, output, `goss_tests_outcomes_duration_milliseconds{outcome="pass",type="file"} 0`)
-	assert.Contains(t, output, `goss_tests_outcomes_duration_milliseconds{outcome="fail",type="file"} 0`)
-	assert.Contains(t, output, `goss_tests_outcomes_duration_milliseconds{outcome="skip",type="file"} 10`)
-	assert.Contains(t, output, `goss_tests_outcomes_total{outcome="pass",type="command"} 2`)
-	assert.Contains(t, output, `goss_tests_outcomes_total{outcome="fail",type="command"} 1`)
-	assert.Contains(t, output, `goss_tests_outcomes_total{outcome="skip",type="command"} 0`)
-	assert.Contains(t, output, `goss_tests_outcomes_total{outcome="pass",type="file"} 0`)
-	assert.Contains(t, output, `goss_tests_outcomes_total{outcome="fail",type="file"} 0`)
-	assert.Contains(t, output, `goss_tests_outcomes_total{outcome="skip",type="file"} 1`)
-	assert.Contains(t, output, `goss_tests_run_duration_milliseconds{outcome="skip"} 60000`)
-	assert.Contains(t, output, `goss_tests_run_outcomes_total{outcome="skip"} 1`)
+			defer resetMetrics()
+
+			exitCode := outputer.Output(buf, makeResults(testCase.results...), util.OutputConfig{})
+			assert.Equal(t, 0, exitCode)
+
+			output := buf.String()
+			t.Logf(output)
+			for _, metric := range testCase.expectedMetrics {
+				assert.Contains(t, output, metric)
+			}
+		})
+	}
 }
 
 func makeResults(results ...resource.TestResult) <-chan []resource.TestResult {
@@ -72,4 +497,47 @@ func makeResults(results ...resource.TestResult) <-chan []resource.TestResult {
 		close(out)
 	}()
 	return out
+}
+
+func resetMetrics() {
+	testOutcomes.Reset()
+	testDurations.Reset()
+	runOutcomes.Reset()
+	runDuration.Reset()
+}
+
+func TestCanChangeOverallOutcome(t *testing.T) {
+	testCases := map[string]map[string]bool{
+		resource.OutcomePass: {
+			resource.OutcomePass:    true,
+			resource.OutcomeSkip:    false,
+			resource.OutcomeFail:    true,
+			resource.OutcomeUnknown: true,
+		},
+		resource.OutcomeSkip: {
+			resource.OutcomePass:    true,
+			resource.OutcomeSkip:    true,
+			resource.OutcomeFail:    true,
+			resource.OutcomeUnknown: true,
+		},
+		resource.OutcomeFail: {
+			resource.OutcomePass:    false,
+			resource.OutcomeSkip:    false,
+			resource.OutcomeFail:    false,
+			resource.OutcomeUnknown: false,
+		},
+		resource.OutcomeUnknown: {
+			resource.OutcomePass:    false,
+			resource.OutcomeSkip:    false,
+			resource.OutcomeFail:    true,
+			resource.OutcomeUnknown: false,
+		},
+	}
+	for current, expectations := range testCases {
+		for result, canChange := range expectations {
+			t.Run(fmt.Sprintf("%s/%s", current, result), func(t *testing.T) {
+				assert.Equalf(t, canChange, canChangeOverallOutcome(current, result), "canChangeOverallOutcome(%v, %v)", current, result)
+			})
+		}
+	}
 }


### PR DESCRIPTION
The prometheus metric goss_tests_run_outcomes_total has a label called 'outcome' which suffers from two problems:

1. It won't be set to 'pass' in case all tests succeed
2. The order of test results determines the final value of the label, e.g. if there is a failed & skipped test then the outcome will be skipped, but if order of results is reversed the outcome will become failed.

This commit fixes both by introducing a helper function which determines whether the outcome can be changed and adds tests to verify that behavior.

fixes #789

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
