### PR TITLE
feat: s390x build option added to build package for IBM Z series

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,8 @@ deploy:
     - release/goss-linux-arm.sha256
     - release/goss-linux-arm64
     - release/goss-linux-arm64.sha256
+    - release/goss-linux-s390x
+    - release/goss-linux-s390x.sha256
     - release/goss-windows-amd64.exe
     - release/goss-windows-amd64.exe.sha256
     - extras/dgoss/dgoss

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ release:
 	$(MAKE) clean
 	$(MAKE) build
 
-build: release/goss-darwin-amd64 release/goss-darwin-arm64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-linux-arm64 release/goss-windows-amd64
+build: release/goss-darwin-amd64 release/goss-darwin-arm64 release/goss-linux-386 release/goss-linux-amd64 release/goss-linux-arm release/goss-linux-arm64 release/goss-linux-s390x release/goss-windows-amd64
 
 gen:
 	$(info INFO: Starting build $@)


### PR DESCRIPTION
A new build option (release/goss-linux-s390x) is added in the Makefile to release package for s390x architecture.

##### Checklist
- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

### Description of change
A new build option (release/goss-linux-s390x) is added in the Makefile to release package for s390x architecture.
