### PR TITLE
add more labels to prometheus output

### DIFF
--- a/docs/manual.md
+++ b/docs/manual.md
@@ -270,7 +270,7 @@ The `application/vnd.goss-{output format}` media type can be used in the `Accept
   * `silent` - No output. Avoids exposing system information (e.g. when serving tests as a healthcheck endpoint)
 * `--format-options`, `-o` (output format option)
   * `perfdata` - Outputs Nagios "performance data". Applies to `nagios` output
-  * `verbose`  - Gives verbose output. Applies to `nagios` output
+  * `verbose`  - Gives verbose output. Applies to `nagios` and `prometheus` output
   * `pretty`   - Pretty printing for the `json` output
   * `sort`     - Sorts the results
 * `--loglevel level`, `-L level` - Goss logging verbosity level (default: `INFO`). `level` can be one of `TRACE | DEBUG | INFO | WARN | ERROR | FATAL`. Lower levels of tracing include all upper levels traces also (ie. INFO include WARN, ERROR and FATAL outputs).

--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -13,67 +13,38 @@ import (
 )
 
 const (
-	labelType    = "type"
-	labelOutcome = "outcome"
+	labelType       = "type"
+	labelOutcome    = "outcome"
+	labelResourceId = "resource_id"
 )
 
 var (
-	testOutcomes = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "goss",
-		Subsystem: "tests",
-		Name:      "outcomes_total",
-		Help:      "The number of test-outcomes from this run.",
-	}, []string{labelType, labelOutcome})
-	testDurations = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "goss",
-		Subsystem: "tests",
-		Name:      "outcomes_duration_milliseconds",
-		Help:      "The duration of tests from this run. Note; tests run concurrently.",
-	}, []string{labelType, labelOutcome})
-	runOutcomes = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "goss",
-		Subsystem: "tests",
-		Name:      "run_outcomes_total",
-		Help:      "The outcomes of this run as a whole.",
-	}, []string{labelOutcome})
-	runDuration = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "goss",
-		Subsystem: "tests",
-		Name:      "run_duration_milliseconds",
-		Help:      "The end-to-end duration of this run.",
-	}, []string{labelOutcome})
+	registry      *prometheus.Registry
+	testOutcomes  *prometheus.CounterVec
+	testDurations *prometheus.CounterVec
+	runOutcomes   *prometheus.CounterVec
+	runDuration   *prometheus.CounterVec
 )
 
 // Prometheus renders metrics in prometheus.io text-format https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format
 type Prometheus struct{}
 
-// NewPrometheus creates and initialises a new Prometheus Outputer (to avoid missing metrics)
-func NewPrometheus() *Prometheus {
-	outputer := &Prometheus{}
-	outputer.init()
-	return outputer
-}
-
-func (r *Prometheus) init() {
-	// Avoid missing metrics: https://prometheus.io/docs/practices/instrumentation/#avoid-missing-metrics
-	for resourceType := range resource.Resources() {
-		for _, outcome := range resource.HumanOutcomes() {
-			testOutcomes.WithLabelValues(resourceType, outcome).Add(0)
-			testDurations.WithLabelValues(resourceType, outcome).Add(0)
-		}
-	}
-	runOutcomes.WithLabelValues(labelOutcome).Add(0)
-	runDuration.WithLabelValues(labelOutcome).Add(0)
-}
-
 // ValidOptions is a list of valid format options for prometheus
 func (r Prometheus) ValidOptions() []*formatOption {
-	return []*formatOption{}
+	return []*formatOption{
+		{name: foVerbose},
+	}
 }
 
 // Output converts the results into the prometheus text-format.
 func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 	outConfig util.OutputConfig) (exitCode int) {
+	verbose := util.IsValueInList(foVerbose, outConfig.FormatOptions)
+
+	if registry == nil {
+		setupMetrics(verbose)
+	}
+
 	overallOutcome := resource.OutcomeUnknown
 	var startTime time.Time
 	for resultGroup := range results {
@@ -83,8 +54,14 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 			}
 			resType := strings.ToLower(tr.ResourceType)
 			outcome := tr.ToOutcome()
-			testOutcomes.WithLabelValues(resType, outcome).Inc()
-			testDurations.WithLabelValues(resType, outcome).Add(float64(tr.Duration.Milliseconds()))
+			if verbose {
+				resId := tr.ResourceId
+				testOutcomes.WithLabelValues(resType, outcome, resId).Inc()
+				testDurations.WithLabelValues(resType, outcome, resId).Add(float64(tr.Duration.Milliseconds()))
+			} else {
+				testOutcomes.WithLabelValues(resType, outcome).Inc()
+				testDurations.WithLabelValues(resType, outcome).Add(float64(tr.Duration.Milliseconds()))
+			}
 			if i == 0 || canChangeOverallOutcome(overallOutcome, outcome) {
 				overallOutcome = outcome
 			}
@@ -94,7 +71,7 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 	runOutcomes.WithLabelValues(overallOutcome).Inc()
 	runDuration.WithLabelValues(overallOutcome).Add(float64(time.Since(startTime).Milliseconds()))
 
-	metricsFamilies, err := prometheus.DefaultGatherer.Gather()
+	metricsFamilies, err := registry.Gather()
 	if err != nil {
 		return -1
 	}
@@ -107,6 +84,43 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 	}
 
 	return 0
+}
+
+func setupMetrics(verbose bool) {
+	registry = prometheus.NewRegistry()
+	factory := promauto.With(registry)
+
+	var testLabels []string
+	if verbose {
+		testLabels = []string{labelType, labelOutcome, labelResourceId}
+	} else {
+		testLabels = []string{labelType, labelOutcome}
+	}
+
+	testOutcomes = factory.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "goss",
+		Subsystem: "tests",
+		Name:      "outcomes_total",
+		Help:      "The number of test-outcomes from this run.",
+	}, testLabels)
+	testDurations = factory.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "goss",
+		Subsystem: "tests",
+		Name:      "outcomes_duration_milliseconds",
+		Help:      "The duration of tests from this run. Note; tests run concurrently.",
+	}, testLabels)
+	runOutcomes = factory.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "goss",
+		Subsystem: "tests",
+		Name:      "run_outcomes_total",
+		Help:      "The outcomes of this run as a whole.",
+	}, []string{labelOutcome})
+	runDuration = factory.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "goss",
+		Subsystem: "tests",
+		Name:      "run_duration_milliseconds",
+		Help:      "The end-to-end duration of this run.",
+	}, []string{labelOutcome})
 }
 
 func canChangeOverallOutcome(current, result string) bool {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

This adds a `resource_id` label to each test-specific metric if the `verbose` format option was enabled. This assumes that the combination of resource ID and resource type is unique.

Since we only have access to format options in the `Output` method, we are creating metrics during the first run of that method.

Metrics can only be registered once for any given set of labels, so we create a custom registry and use the existence of that as a check whether we need to create/register metrics. This has the added benefit of simplifying the test a tiny bit, and it exposes even less metrics on the /healthz endpoint.

fixes #862

Pinging @petemounce @aelsabbahy 