### PR TITLE
Command optional exec style

### DIFF
--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -173,11 +173,14 @@ command:
     retry_delay: 500  # Delay in milliseconds before each retry; duration strings like 500ms or 2s also work
 ```
 
-The `exec` attribute specifies the command to run. It defaults to the name of
-the hash key and can be given in two forms:
+The `exec` attribute specifies the command to run.
+It defaults to the name of the hash key and can be given in two forms:
 
 * A **string**, which is executed through the shell (e.g. `/bin/sh -c "<string>"` on Unix).
-* An **array of strings**, where the first element is the program and the rest are its arguments. The command is invoked directly, without a shell. This is useful in environments that have no shell, such as `scratch`/distroless containers, and for passing arguments containing spaces or special characters verbatim.
+* An **array of strings**, where the first element is the program and the rest are its arguments.
+  The command is invoked directly, without a shell.
+  This is useful in environments that have no shell, such as `scratch`/distroless containers.
+  It also allows arguments containing spaces or special characters to be passed verbatim.
 
 ```yaml
 command:

--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -173,6 +173,20 @@ command:
     retry_delay: 500  # Delay in milliseconds before each retry; duration strings like 500ms or 2s also work
 ```
 
+The `exec` attribute specifies the command to run. It defaults to the name of
+the hash key and can be given in two forms:
+
+* A **string**, which is executed through the shell (e.g. `/bin/sh -c "<string>"` on Unix).
+* An **array of strings**, where the first element is the program and the rest are its arguments. The command is invoked directly, without a shell. This is useful in environments that have no shell, such as `scratch`/distroless containers, and for passing arguments containing spaces or special characters verbatim.
+
+```yaml
+command:
+  figlet:
+    exit-status: 0
+    # exec style: run /figlet directly with argument "test"
+    exec: ["/figlet", "test"]
+```
+
 `stdout` and `stderr` can be a string or [pattern](#patterns)
 
 !!! warning "An empty list asserts nothing"

--- a/docs/platforms.md
+++ b/docs/platforms.md
@@ -55,6 +55,7 @@ This matrix attempts to track parity across platforms.
 |                     | local-address       | {{ fully_supported }}   | {{ no_data }}          | {{ work_partially }}    |
 |                     | timeout             | {{ fully_supported }}   | {{ not_automated }}    | {{ not_automated }}     |
 | **command**         |                     | {{ fully_supported }}   | {{ work_partially }}   | {{ work_partially }}    |
+|                     | exec                | {{ fully_supported }}   | {{ fully_supported }}  | {{ fully_supported }}   |
 |                     | exit-status         | {{ fully_supported }}   | {{ work_partially }}   | {{ work_partially }}    |
 |                     | stdout              | {{ fully_supported }}   | {{ work_partially }}   | {{ work_partially }}    |
 |                     | stderr              | {{ fully_supported }}   | {{ not_automated }}    | {{ not_automated }}     |

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -47,8 +47,12 @@ definitions:
         type: integer
         description: "Validates the exit-status and output of a command"
       exec:
-        description: "command to execute, defaults to the hash key"
-        type: string
+        description: "command to execute, defaults to the hash key. A string is run through the shell; a list of strings is executed directly (no shell), useful when no shell exists (e.g. scratch/distroless images)"
+        oneOf:
+          - type: string
+          - type: array
+            items:
+              type: string
       stdout:
         type: array
         description: "can be a string or pattern, see https://goss.rocks/gossfile#patterns"

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/tidwall/gjson v1.19.0
 	github.com/urfave/cli/v3 v3.10.1
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/sys v0.47.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.1
@@ -52,7 +53,6 @@ require (
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/tidwall/match v1.2.0 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -17,6 +17,16 @@ command:
     exec: false
     exit-status: 0
     skip: true
+  command-exec-style:
+    exec: [uname]
+    exit-status: 0
+    stdout:
+    - /Linux/
+  command-exec-style-args:
+    exec: ["uname", "-s"]
+    exit-status: 0
+    stdout:
+    - /Linux/
 file:
 {{range mkSlice "/etc/PAsswD" "/etc/group"}}
   {{. | toLower}}:

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -44,9 +44,9 @@ out=$(docker_exec "/goss/$os/goss-linux-$arch" --vars "/goss/vars.yaml" --vars-i
 echo "$out"
 
 if [[ $os == "arch" ]]; then
-    egrep -q 'Count: 108, Failed: 0, Skipped: 3' <<<"$out"
+    egrep -q 'Count: 112, Failed: 0, Skipped: 3' <<<"$out"
 else
-    egrep -q 'Count: 129, Failed: 0, Skipped: 5' <<<"$out"
+    egrep -q 'Count: 133, Failed: 0, Skipped: 5' <<<"$out"
 fi
 
 if [[ ! $os == "arch" ]]; then

--- a/resource/command.go
+++ b/resource/command.go
@@ -13,17 +13,17 @@ import (
 )
 
 type Command struct {
-	Title      string     `json:"title,omitempty" yaml:"title,omitempty"`
-	Meta       meta       `json:"meta,omitempty" yaml:"meta,omitempty"`
-	id         string     `json:"-" yaml:"-"`
-	Exec       string     `json:"exec,omitempty" yaml:"exec,omitempty"`
-	ExitStatus matcher    `json:"exit-status" yaml:"exit-status"`
-	Stdout     matcher    `json:"stdout" yaml:"stdout"`
-	Stderr     matcher    `json:"stderr" yaml:"stderr"`
-	Timeout    int        `json:"timeout" yaml:"timeout"`
-	Skip       bool       `json:"skip,omitempty" yaml:"skip,omitempty"`
-	RetryCount int        `json:"retry_count,omitempty" yaml:"retry_count,omitempty"`
-	RetryDelay RetryDelay `json:"retry_delay,omitempty" yaml:"retry_delay,omitempty"`
+	Title      string            `json:"title,omitempty" yaml:"title,omitempty"`
+	Meta       meta              `json:"meta,omitempty" yaml:"meta,omitempty"`
+	id         string            `json:"-" yaml:"-"`
+	Exec       *util.ExecCommand `json:"exec,omitempty" yaml:"exec,omitempty"`
+	ExitStatus matcher           `json:"exit-status" yaml:"exit-status"`
+	Stdout     matcher           `json:"stdout" yaml:"stdout"`
+	Stderr     matcher           `json:"stderr" yaml:"stderr"`
+	Timeout    int               `json:"timeout" yaml:"timeout"`
+	Skip       bool              `json:"skip,omitempty" yaml:"skip,omitempty"`
+	RetryCount int               `json:"retry_count,omitempty" yaml:"retry_count,omitempty"`
+	RetryDelay RetryDelay        `json:"retry_delay,omitempty" yaml:"retry_delay,omitempty"`
 }
 
 const (
@@ -43,9 +43,17 @@ func (c *Command) TypeName() string { return CommandResourceName }
 
 func (c *Command) GetTitle() string { return c.Title }
 func (c *Command) GetMeta() meta    { return c.Meta }
-func (c *Command) GetExec() string {
-	if c.Exec != "" {
-		return c.Exec
+
+// GetExec returns the command to run: shell style as a string, exec style as a
+// []string, or the resource id when no exec was specified.
+func (c *Command) GetExec() any {
+	if c.Exec != nil {
+		if c.Exec.CmdStr != "" {
+			return c.Exec.CmdStr
+		}
+		if len(c.Exec.CmdSlice) > 0 {
+			return c.Exec.CmdSlice
+		}
 	}
 	return c.id
 }
@@ -91,10 +99,14 @@ func allTestsPassed(results []TestResult) bool {
 }
 
 func NewCommand(sysCommand system.Command, config util.Config) (*Command, error) {
-	command := sysCommand.Command()
+	exec := sysCommand.Command()
+	id := exec.CmdStr
+	if id == "" && len(exec.CmdSlice) > 0 {
+		id = exec.CmdSlice[0]
+	}
 	exitStatus, err := sysCommand.ExitStatus()
 	c := &Command{
-		id:         command,
+		id:         id,
 		ExitStatus: exitStatus,
 		Stdout:     "",
 		Stderr:     "",

--- a/resource/command_test.go
+++ b/resource/command_test.go
@@ -4,7 +4,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestCommandGetExec(t *testing.T) {

--- a/resource/command_test.go
+++ b/resource/command_test.go
@@ -1,0 +1,62 @@
+package resource
+
+import (
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCommandGetExec(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  any
+	}{
+		{
+			name:  "no exec falls back to the id",
+			input: "foo:\n  exit-status: 0\n",
+			want:  "foo",
+		},
+		{
+			name:  "string exec is shell style",
+			input: "foo:\n  exit-status: 0\n  exec: echo hi\n",
+			want:  "echo hi",
+		},
+		{
+			name:  "list exec is exec style",
+			input: "foo:\n  exit-status: 0\n  exec: [/bin/echo, hello world]\n",
+			want:  []string{"/bin/echo", "hello world"},
+		},
+		{
+			name:  "bool scalar exec keeps legacy string behavior",
+			input: "foo:\n  exit-status: 0\n  exec: true\n",
+			want:  "true",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m CommandMap
+			if err := yaml.Unmarshal([]byte(tt.input), &m); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			cmd, ok := m["foo"]
+			if !ok {
+				t.Fatalf("expected foo resource, got %+v", m)
+			}
+			got := cmd.GetExec()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("GetExec() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandInvalidExec(t *testing.T) {
+	input := "foo:\n  exit-status: 0\n  exec: {a: b}\n"
+	var m CommandMap
+	if err := yaml.Unmarshal([]byte(input), &m); err == nil {
+		t.Fatalf("expected error for mapping exec, got %+v", m)
+	}
+}

--- a/resource/retry_test.go
+++ b/resource/retry_test.go
@@ -50,13 +50,13 @@ func (f *fakeDNS) Resolvable() (bool, error) { return f.resolvableFn() }
 func (f *fakeDNS) Addrs() ([]string, error)  { return f.addrsFn() }
 
 type fakeCommand struct {
-	command      string
+	command      util.ExecCommand
 	exitStatusFn func() (int, error)
 	stdoutFn     func() (io.Reader, error)
 	stderrFn     func() (io.Reader, error)
 }
 
-func (f *fakeCommand) Command() string            { return f.command }
+func (f *fakeCommand) Command() util.ExecCommand  { return f.command }
 func (f *fakeCommand) Exists() (bool, error)      { return true, nil }
 func (f *fakeCommand) ExitStatus() (int, error)   { return f.exitStatusFn() }
 func (f *fakeCommand) Stdout() (io.Reader, error) { return f.stdoutFn() }
@@ -267,11 +267,18 @@ func TestDNSValidateRetries(t *testing.T) {
 func TestCommandValidateRetries(t *testing.T) {
 	commandCalls := 0
 	sys := &system.System{
-		NewCommand: func(_ context.Context, command string, _ *system.System, _ util.Config) system.Command {
+		NewCommand: func(_ context.Context, command any, _ *system.System, _ util.Config) system.Command {
 			commandCalls++
 			attempt := commandCalls
+			var exec util.ExecCommand
+			switch c := command.(type) {
+			case string:
+				exec = util.ExecCommand{CmdStr: c}
+			case []string:
+				exec = util.ExecCommand{CmdSlice: c}
+			}
 			return &fakeCommand{
-				command: command,
+				command: exec,
 				exitStatusFn: func() (int, error) {
 					if attempt == 1 {
 						return 1, nil
@@ -290,7 +297,7 @@ func TestCommandValidateRetries(t *testing.T) {
 
 	cmd := &Command{
 		id:         "echo ok",
-		Exec:       "echo ok",
+		Exec:       &util.ExecCommand{CmdStr: "echo ok"},
 		ExitStatus: 0,
 		Stdout:     []any{"ok"},
 		RetryCount: 1,

--- a/system/command.go
+++ b/system/command.go
@@ -18,7 +18,7 @@ type ContextKey struct{}
 var CommandIDKey = ContextKey{}
 
 type Command interface {
-	Command() string
+	Command() util.ExecCommand
 	Exists() (bool, error)
 	ExitStatus() (int, error)
 	Stdout() (io.Reader, error)
@@ -27,7 +27,7 @@ type Command interface {
 
 type DefCommand struct {
 	Ctx        context.Context
-	command    string
+	command    util.ExecCommand
 	exitStatus int
 	stdout     io.Reader
 	stderr     io.Reader
@@ -36,12 +36,27 @@ type DefCommand struct {
 	err        error
 }
 
-func NewDefCommand(ctx context.Context, command string, system *System, config util.Config) Command {
-	return &DefCommand{
+// NewDefCommand accepts a command specified either shell style (string) or exec
+// style ([]string). The concrete type is validated here; an unexpected type is
+// recorded as an error on the returned Command so it surfaces as a failing test
+// result rather than a panic. Values loaded from a gossfile are already
+// validated by util.ExecCommand's unmarshalers, so this only guards against
+// programming errors.
+func NewDefCommand(ctx context.Context, command any, system *System, config util.Config) Command {
+	c := &DefCommand{
 		Ctx:     ctx,
-		command: command,
 		Timeout: config.TimeOutMilliSeconds(),
 	}
+	switch cmd := command.(type) {
+	case string:
+		c.command = util.ExecCommand{CmdStr: cmd}
+	case []string:
+		c.command = util.ExecCommand{CmdSlice: cmd}
+	default:
+		c.err = fmt.Errorf("command type must be either a string or a list of strings, got %T", command)
+		c.loaded = true
+	}
+	return c
 }
 
 func (c *DefCommand) setup() error {
@@ -50,7 +65,16 @@ func (c *DefCommand) setup() error {
 	}
 	c.loaded = true
 
-	cmd := commandWrapper(c.command)
+	var cmd *util.Command
+	switch {
+	case c.command.CmdStr != "":
+		cmd = commandWrapper(c.command.CmdStr)
+	case len(c.command.CmdSlice) > 0:
+		cmd = util.NewCommand(c.command.CmdSlice[0], c.command.CmdSlice[1:]...)
+	default:
+		c.err = fmt.Errorf("empty command")
+		return c.err
+	}
 	err := runCommand(cmd, c.Timeout)
 
 	// We don't care about ExitError since it's covered by status
@@ -70,7 +94,7 @@ func (c *DefCommand) setup() error {
 	return c.err
 }
 
-func (c *DefCommand) Command() string {
+func (c *DefCommand) Command() util.ExecCommand {
 	return c.command
 }
 

--- a/system/command.go
+++ b/system/command.go
@@ -3,6 +3,7 @@ package system
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -16,6 +17,10 @@ type ContextKey struct{}
 
 // CommandIDKey is the only instance that must be used everywhere.
 var CommandIDKey = ContextKey{}
+
+// errEmptyCommand is returned when a command has neither a shell string nor an
+// exec-style argument list.
+var errEmptyCommand = errors.New("empty command")
 
 type Command interface {
 	Command() util.ExecCommand
@@ -72,7 +77,7 @@ func (c *DefCommand) setup() error {
 	case len(c.command.CmdSlice) > 0:
 		cmd = util.NewCommand(c.command.CmdSlice[0], c.command.CmdSlice[1:]...)
 	default:
-		c.err = fmt.Errorf("empty command")
+		c.err = errEmptyCommand
 		return c.err
 	}
 	err := runCommand(cmd, c.Timeout)

--- a/system/system.go
+++ b/system/system.go
@@ -28,7 +28,7 @@ type System struct {
 	NewService     func(context.Context, string, *System, util2.Config) Service
 	NewUser        func(context.Context, string, *System, util2.Config) User
 	NewGroup       func(context.Context, string, *System, util2.Config) Group
-	NewCommand     func(context.Context, string, *System, util2.Config) Command
+	NewCommand     func(context.Context, any, *System, util2.Config) Command
 	NewDNS         func(context.Context, string, *System, util2.Config) DNS
 	NewProcess     func(context.Context, string, *System, util2.Config) Process
 	NewGossfile    func(context.Context, string, *System, util2.Config) Gossfile

--- a/util/command.go
+++ b/util/command.go
@@ -24,6 +24,10 @@ type ExecCommand struct {
 	CmdSlice []string
 }
 
+// errExecCommandType is returned when a command value is neither a string
+// (shell style) nor a list of strings (exec style).
+var errExecCommandType = errors.New("command must be a string or a list of strings")
+
 // UnmarshalJSON accepts either a JSON string (shell style) or a JSON array of
 // strings (exec style). Anything else is an error.
 func (e *ExecCommand) UnmarshalJSON(data []byte) error {
@@ -34,7 +38,7 @@ func (e *ExecCommand) UnmarshalJSON(data []byte) error {
 	// Fall back to exec style.
 	e.CmdStr = ""
 	if err := json.Unmarshal(data, &e.CmdSlice); err != nil {
-		return errors.New("command must be a string or a list of strings")
+		return errExecCommandType
 	}
 	return nil
 }
@@ -50,7 +54,7 @@ func (e *ExecCommand) UnmarshalYAML(unmarshal func(any) error) error {
 	// Fall back to exec style.
 	e.CmdStr = ""
 	if err := unmarshal(&e.CmdSlice); err != nil {
-		return errors.New("command must be a string or a list of strings")
+		return errExecCommandType
 	}
 	return nil
 }

--- a/util/command.go
+++ b/util/command.go
@@ -2,11 +2,76 @@ package util
 
 import (
 	"bytes"
+	"encoding/json"
 
 	//"fmt"
+	"errors"
 	"os/exec"
 	"syscall"
 )
+
+// ExecCommand represents a command that can be specified either shell style,
+// as a single string that is run through the shell (`sh -c "<string>"`), or
+// exec style, as an explicit list of arguments where the first element is the
+// program and the rest are its arguments (no shell involved). This mirrors the
+// shell/exec forms of Dockerfile's RUN/ENTRYPOINT/CMD instructions.
+//
+// Exactly one of CmdStr or CmdSlice is set. It is useful for environments
+// without a shell, such as distroless/scratch containers, and for passing
+// arguments containing spaces or special characters verbatim.
+type ExecCommand struct {
+	CmdStr   string
+	CmdSlice []string
+}
+
+// UnmarshalJSON accepts either a JSON string (shell style) or a JSON array of
+// strings (exec style). Anything else is an error.
+func (e *ExecCommand) UnmarshalJSON(data []byte) error {
+	// Try shell style first.
+	if err := json.Unmarshal(data, &e.CmdStr); err == nil {
+		return nil
+	}
+	// Fall back to exec style.
+	e.CmdStr = ""
+	if err := json.Unmarshal(data, &e.CmdSlice); err != nil {
+		return errors.New("command must be a string or a list of strings")
+	}
+	return nil
+}
+
+// UnmarshalYAML accepts either a YAML scalar (shell style) or a YAML sequence
+// of strings (exec style). Anything else is an error.
+func (e *ExecCommand) UnmarshalYAML(unmarshal func(any) error) error {
+	// Try shell style first. A bool/int scalar decodes into the string, which
+	// preserves the long-standing behavior of `exec: true` meaning `exec: "true"`.
+	if err := unmarshal(&e.CmdStr); err == nil {
+		return nil
+	}
+	// Fall back to exec style.
+	e.CmdStr = ""
+	if err := unmarshal(&e.CmdSlice); err != nil {
+		return errors.New("command must be a string or a list of strings")
+	}
+	return nil
+}
+
+// MarshalJSON emits the command as a JSON string (shell style) or array of
+// strings (exec style), matching what UnmarshalJSON accepts.
+func (e ExecCommand) MarshalJSON() ([]byte, error) {
+	if e.CmdStr != "" {
+		return json.Marshal(e.CmdStr)
+	}
+	return json.Marshal(e.CmdSlice)
+}
+
+// MarshalYAML emits the command as a YAML scalar (shell style) or sequence of
+// strings (exec style), matching what UnmarshalYAML accepts.
+func (e ExecCommand) MarshalYAML() (any, error) {
+	if e.CmdStr != "" {
+		return e.CmdStr, nil
+	}
+	return e.CmdSlice, nil
+}
 
 type Command struct {
 	name           string

--- a/util/command_test.go
+++ b/util/command_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 )
 
 func TestExecCommandUnmarshalYAML(t *testing.T) {

--- a/util/command_test.go
+++ b/util/command_test.go
@@ -1,0 +1,168 @@
+package util
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestExecCommandUnmarshalYAML(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    ExecCommand
+		wantErr bool
+	}{
+		{
+			name:  "string is shell style",
+			input: "echo hello world",
+			want:  ExecCommand{CmdStr: "echo hello world"},
+		},
+		{
+			name:  "flow sequence is exec style",
+			input: "[/bin/echo, hello world]",
+			want:  ExecCommand{CmdSlice: []string{"/bin/echo", "hello world"}},
+		},
+		{
+			name:  "block sequence is exec style",
+			input: "\n- /bin/echo\n- hello world\n",
+			want:  ExecCommand{CmdSlice: []string{"/bin/echo", "hello world"}},
+		},
+		{
+			name:  "bool scalar decodes to its string form (exec: true)",
+			input: "true",
+			want:  ExecCommand{CmdStr: "true"},
+		},
+		{
+			name:  "null is empty",
+			input: "null",
+			want:  ExecCommand{},
+		},
+		{
+			name:    "mapping is invalid",
+			input:   "{a: b}",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got ExecCommand
+			err := yaml.Unmarshal([]byte(tt.input), &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecCommandUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    ExecCommand
+		wantErr bool
+	}{
+		{
+			name:  "string is shell style",
+			input: `"echo hello world"`,
+			want:  ExecCommand{CmdStr: "echo hello world"},
+		},
+		{
+			name:  "array is exec style",
+			input: `["/bin/echo", "hello world"]`,
+			want:  ExecCommand{CmdSlice: []string{"/bin/echo", "hello world"}},
+		},
+		{
+			name:    "number is invalid",
+			input:   `5`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got ExecCommand
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %+v", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExecCommandMarshalRoundTrip(t *testing.T) {
+	shell := ExecCommand{CmdStr: "echo hi"}
+	execStyle := ExecCommand{CmdSlice: []string{"/bin/echo", "hi"}}
+
+	for _, want := range []ExecCommand{shell, execStyle} {
+		yb, err := yaml.Marshal(want)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var gotY ExecCommand
+		if err := yaml.Unmarshal(yb, &gotY); err != nil {
+			t.Fatalf("yaml round trip %v: %v", want, err)
+		}
+		if !reflect.DeepEqual(gotY, want) {
+			t.Fatalf("yaml round trip: got %+v, want %+v (marshaled: %q)", gotY, want, yb)
+		}
+
+		jb, err := json.Marshal(want)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var gotJ ExecCommand
+		if err := json.Unmarshal(jb, &gotJ); err != nil {
+			t.Fatalf("json round trip %v: %v", want, err)
+		}
+		if !reflect.DeepEqual(gotJ, want) {
+			t.Fatalf("json round trip: got %+v, want %+v (marshaled: %q)", gotJ, want, jb)
+		}
+	}
+}
+
+// holder mirrors how resource.Command embeds ExecCommand with omitempty so we
+// can assert an unset command is omitted from serialized output in both formats.
+type execHolder struct {
+	Exec *ExecCommand `yaml:"exec,omitempty" json:"exec,omitempty"`
+	Name string       `yaml:"name,omitempty" json:"name,omitempty"`
+}
+
+func TestExecCommandOmittedWhenUnset(t *testing.T) {
+	yb, err := yaml.Marshal(execHolder{Name: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(yb) != "name: x\n" {
+		t.Fatalf("expected exec omitted from yaml, got %q", yb)
+	}
+
+	jb, err := json.Marshal(execHolder{Name: "x"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(jb) != `{"name":"x"}` {
+		t.Fatalf("expected exec omitted from json, got %q", jb)
+	}
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

Fixes #870

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-linux-all` (UNIX) passes. CI will also test this
- [ ] Windows platform
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)
- [x] Update goss yaml schema
- [x] Update goss JSON schema

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

This change allows specifying a command to be executed exec style without a shell.
This change is backwards compatible, and existing goss configuration files should continue to work as expected.
This change is needed for operating in environments where a shell doesn't exist, such as testing a distroless docker image.
The syntax is inspired by the Dockerfile `RUN`, `ENTRYPOINT`, `CMD` instructions that can take either a string (shell style), or a list (exec style).  This allows specifying arguments that contain spaces, etc, as the argument list is explicit.

Shell syntax (unchanged from before):

```yaml
command:
  figlet:
    exit-status: 0
    exec: figlet test
```

This would be wrapped and executed as `sh -c "figlet test"`

Exec syntax (this change introduces):

```yaml
command:
  figlet:
    exit-status: 0
    exec:
      - figlet
      - test
```

This would be executed directly, without a shell, as `figlet test`, where `figlet` is arg 0 and `test` is arg 1.

The above could use alternative yaml syntax:

```yaml
command:
  figlet:
    exit-status: 0
    exec: [figlet, test]
```
