### PR TITLE
IDE json schema: skip is not mandatory for process tests

### DIFF
--- a/docs/goss-json-schema.yaml
+++ b/docs/goss-json-schema.yaml
@@ -385,16 +385,12 @@ definitions:
   processTest:
     required:
       - running
-      - skip
     properties:
       title: { "$ref":"#/definitions/title" }
       meta: { "$ref":"#/definitions/meta" }
       running:
         type: boolean
         default: true
-      skip:
-        type: boolean
-        default: false
   serviceTest:
     required:
       - enabled


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
The json schema used by IDEs claims that "skip" is a mandatory property of a process test.

![image](https://github.com/goss-org/goss/assets/1173314/7e71ddb1-1a99-4dd2-b989-ef7cdf0aa6ec)

Adding the skip property causes goss to fail with this error message:
```
Error: Invalid Attribute for Process:caddy: skip
```

I can only presume that at some point the skip attribute was supported and required, but was later removed. It seems the json spec file wasn't modified with this change.
