### PR TITLE
Added timeout for mount command in goss

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -387,6 +387,9 @@ func main() {
 				{
 					Name:  resource.MountResourceKey,
 					Usage: "add new mount",
+					Flags: []cli.Flag{
+						timeoutFlag(1000 * time.Millisecond),
+					},
 					Action: func(c *cli.Context) error {
 						fatalAlphaIfNeeded(c)
 						return goss.AddResources(c.GlobalString("gossfile"), resource.MountResourceName, c.Args(), newRuntimeConfigFromCLI(c))

--- a/docs/goss.yaml
+++ b/docs/goss.yaml
@@ -139,6 +139,7 @@ matching:
 mount:
   /home:
     exists: true
+    timeout: 1000
     opts:
       - rw
     source: /dev/mapper/fedora-home

--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -396,6 +396,7 @@ mount:
     exists: true
     # optional attributes
     # defaults to hash key
+    timeout: 1000
     mountpoint: /home
     opts:
     - rw

--- a/docs/rendered_goss.yaml
+++ b/docs/rendered_goss.yaml
@@ -111,6 +111,7 @@ kernel-param:
 mount:
   /home:
     exists: true
+    timeout: 1000
     opts:
     - rw
     source: /dev/mapper/fedora-home

--- a/docs/schema.yaml
+++ b/docs/schema.yaml
@@ -317,6 +317,8 @@ definitions:
     required:
       - exists
     properties:
+      timeout:
+        type: integer
       title: { "$ref":"#/definitions/title" }
       meta: { "$ref":"#/definitions/meta" }
       exists:

--- a/integration-tests/goss/alpine3/goss-expected-q.yaml
+++ b/integration-tests/goss/alpine3/goss-expected-q.yaml
@@ -104,6 +104,7 @@ kernel-param:
 mount:
   /dev:
     exists: true
+    timeout: 1000
 http:
   http://google.com:
     status: 301

--- a/integration-tests/goss/alpine3/goss-expected.yaml
+++ b/integration-tests/goss/alpine3/goss-expected.yaml
@@ -148,6 +148,7 @@ mount:
     - rw
     source: tmpfs
     filesystem: tmpfs
+    timeout: 1000
 http:
   http://google.com:
     status: 301

--- a/integration-tests/goss/centos7/goss-expected-q.yaml
+++ b/integration-tests/goss/centos7/goss-expected-q.yaml
@@ -104,6 +104,7 @@ kernel-param:
 mount:
   /dev:
     exists: true
+    timeout: 1000
 http:
   http://google.com:
     status: 301

--- a/integration-tests/goss/centos7/goss-expected.yaml
+++ b/integration-tests/goss/centos7/goss-expected.yaml
@@ -154,6 +154,7 @@ mount:
     - rw
     source: tmpfs
     filesystem: tmpfs
+    timeout: 1000
 http:
   http://google.com:
     status: 301

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -169,6 +169,7 @@ kernel-param:
 mount:
   "/dev":
     exists: true
+    timeout: 1000
     opts:
     - rw
     - nosuid

--- a/integration-tests/goss/trusty/goss-expected-q.yaml
+++ b/integration-tests/goss/trusty/goss-expected-q.yaml
@@ -104,6 +104,7 @@ kernel-param:
 mount:
   /dev:
     exists: true
+    timeout: 1000
 http:
   http://google.com:
     status: 301

--- a/integration-tests/goss/trusty/goss-expected.yaml
+++ b/integration-tests/goss/trusty/goss-expected.yaml
@@ -154,6 +154,7 @@ mount:
     - rw
     source: tmpfs
     filesystem: tmpfs
+    timeout: 1000
 http:
   http://google.com:
     status: 301

--- a/integration-tests/goss/wheezy/goss-expected-q.yaml
+++ b/integration-tests/goss/wheezy/goss-expected-q.yaml
@@ -104,6 +104,7 @@ kernel-param:
 mount:
   /dev:
     exists: true
+    timeout: 1000
 http:
   http://google.com:
     status: 301

--- a/integration-tests/goss/wheezy/goss-expected.yaml
+++ b/integration-tests/goss/wheezy/goss-expected.yaml
@@ -154,6 +154,7 @@ mount:
     - rw
     source: tmpfs
     filesystem: tmpfs
+    timeout: 1000
 http:
   http://google.com:
     status: 301

--- a/resource/mount.go
+++ b/resource/mount.go
@@ -3,9 +3,9 @@ package resource
 import (
 	"context"
 	"fmt"
-
 	"github.com/goss-org/goss/system"
 	"github.com/goss-org/goss/util"
+	"time"
 )
 
 type Mount struct {
@@ -18,6 +18,7 @@ type Mount struct {
 	VfsOpts    matcher `json:"vfs-opts,omitempty" yaml:"vfs-opts,omitempty"`
 	Source     matcher `json:"source,omitempty" yaml:"source,omitempty"`
 	Filesystem matcher `json:"filesystem,omitempty" yaml:"filesystem,omitempty"`
+	Timeout    int     `json:"timeout" yaml:"timeout"`
 	Skip       bool    `json:"skip,omitempty" yaml:"skip,omitempty"`
 	Usage      matcher `json:"usage,omitempty" yaml:"usage,omitempty"`
 }
@@ -55,7 +56,12 @@ func (m *Mount) GetMountPoint() string {
 func (m *Mount) Validate(sys *system.System) []TestResult {
 	ctx := context.WithValue(context.Background(), "id", m.ID())
 	skip := m.Skip
-	sysMount := sys.NewMount(ctx, m.GetMountPoint(), sys, util.Config{})
+
+	if m.Timeout == 0 {
+		m.Timeout = 1000
+	}
+
+	sysMount := sys.NewMount(ctx, m.GetMountPoint(), sys, util.Config{Timeout: time.Duration(m.Timeout) * time.Millisecond})
 
 	var results []TestResult
 	results = append(results, ValidateValue(m, "exists", m.Exists, sysMount.Exists, skip))
@@ -84,8 +90,9 @@ func NewMount(sysMount system.Mount, config util.Config) (*Mount, error) {
 	mountPoint := sysMount.MountPoint()
 	exists, _ := sysMount.Exists()
 	m := &Mount{
-		id:     mountPoint,
-		Exists: exists,
+		id:      mountPoint,
+		Exists:  exists,
+		Timeout: config.TimeOutMilliSeconds(),
 	}
 	if !contains(config.IgnoreList, "opts") {
 		if opts, err := sysMount.Opts(); err == nil {

--- a/system/mount.go
+++ b/system/mount.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/goss-org/goss/util"
 	"github.com/moby/sys/mountinfo"
@@ -26,12 +27,14 @@ type DefMount struct {
 	exists     bool
 	mountInfo  *mountinfo.Info
 	usage      int
+	Timeout    int
 	err        error
 }
 
 func NewDefMount(_ context.Context, mountPoint string, system *System, config util.Config) Mount {
 	return &DefMount{
 		mountPoint: mountPoint,
+		Timeout:    config.TimeOutMilliSeconds(),
 	}
 }
 
@@ -41,7 +44,7 @@ func (m *DefMount) setup() error {
 	}
 	m.loaded = true
 
-	mountInfo, err := getMount(m.mountPoint)
+	mountInfo, err := getMount(m.mountPoint, m.Timeout)
 	if err != nil {
 		m.exists = false
 		m.err = err
@@ -70,9 +73,8 @@ func (m *DefMount) MountPoint() string {
 
 func (m *DefMount) Exists() (bool, error) {
 	if err := m.setup(); err != nil {
-		return false, nil
+		return false, err
 	}
-
 	return m.exists, nil
 }
 
@@ -117,15 +119,33 @@ func (m *DefMount) Usage() (int, error) {
 	return m.usage, nil
 }
 
-func getMount(mountpoint string) (*mountinfo.Info, error) {
-	entries, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(mountpoint))
-	if err != nil {
+func getMount(mountpoint string, timeout int) (*mountinfo.Info, error) {
+	c1 := make(chan *mountinfo.Info, 1)
+	e1 := make(chan error, 1)
+	timeoutD := time.Duration(timeout) * time.Millisecond
+
+	go func() {
+		entries, err := mountinfo.GetMounts(mountinfo.SingleEntryFilter(mountpoint))
+		if err != nil {
+			e1 <- err
+			return
+		}
+		if len(entries) == 0 {
+			e1 <- fmt.Errorf("Mountpoint not found")
+			return
+		}
+		c1 <- entries[0]
+	}()
+
+	select {
+	case result := <-c1:
+		return result, nil
+	case err := <-e1:
 		return nil, err
+	case <-time.After(timeoutD):
+		return nil, fmt.Errorf("getMount operation timed out after %s milliseconds", timeoutD)
 	}
-	if len(entries) == 0 {
-		return nil, fmt.Errorf("Mountpoint not found")
-	}
-	return entries[0], nil
+
 }
 
 func splitMountInfo(s string) []string {


### PR DESCRIPTION
Checklist

- [x] documentation is changed or added 
- [x] make test passed

Description of change

1.  We have noticed that mount tests hung and became unresponsive in some of our production VM.
2. The fix is to add a timeout to mount command similar to addr/command.
3. Default timeout is 1000 ms