### PR TITLE
Update travis-ci build image and revert docs link

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ os:
   - linux
   - windows
 
-dist: trusty
+dist: focal
 osx_image: xcode12.2
 
 services:

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ make build
 
 ## Full Documentation
 
-Documentation is available at <https://goss.rocks/>
+[Full Documentation](https://github.com/goss-org/goss/blob/e73553f9c3065ac297499dafb4f8abef6acb24ad/docs/manual.md)
 
 ## Quick start
 

--- a/integration-tests/goss/generate_goss.sh
+++ b/integration-tests/goss/generate_goss.sh
@@ -63,6 +63,7 @@ goss a "${args[@]}" mount /dev
 sed -i '/- seclabel/d' $SCRIPT_DIR/${OS}/goss-generated-$ARCH.yaml
 sed -i '/- size=/d' $SCRIPT_DIR/${OS}/goss-generated-$ARCH.yaml
 sed -i '/- mode=/d' $SCRIPT_DIR/${OS}/goss-generated-$ARCH.yaml
+sed -i '/- inode64/d' $SCRIPT_DIR/${OS}/goss-generated-$ARCH.yaml
 
 goss a "${args[@]}" http https://www.google.com
 


### PR DESCRIPTION
closes #885

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Trying to fix travis-ci issue blocking release and pointing documentation to old manual until readthedocs is ready.

closes #885 

<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--888.org.readthedocs.build/en/888/

<!-- readthedocs-preview goss end -->