### PR TITLE
add a default user-agent header

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -18,7 +18,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-
 // converts a cli context into a goss Config
 func newRuntimeConfigFromCLI(c *cli.Context) *util.Config {
 	cfg := &util.Config{

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -18,7 +18,6 @@ import (
 	"github.com/urfave/cli"
 )
 
-var version string
 
 // converts a cli context into a goss Config
 func newRuntimeConfigFromCLI(c *cli.Context) *util.Config {
@@ -69,7 +68,7 @@ func timeoutFlag(value time.Duration) cli.DurationFlag {
 func main() {
 	app := cli.NewApp()
 	app.EnableBashCompletion = true
-	app.Version = version
+	app.Version = util.Version
 	app.Name = "goss"
 	app.Usage = "Quick and Easy server validation"
 	app.Flags = []cli.Flag{

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -204,9 +204,7 @@ http:
     request-headers:
       - "Foo: bar"
     headers: ["Content-Type: application/json"]
-    body:
-      - '"Foo": "bar"'
-      - '"user-agent": "goss/0.0.0"'
+    body: ['"Foo": "bar"', '"user-agent": "goss/0.0.0"']
   http://httpbin/headers?host:
     status: 200
     timeout: 60000

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -205,6 +205,11 @@ http:
       - "Foo: bar"
     headers: ["Content-Type: application/json"]
     body: ['"Foo": "bar"']
+  http://httpbin/headers:
+    status: 200
+    timeout: 60000
+    headers: ["Content-Type: application/json"]
+    body: ['"User-Agent": "goss']
   http://httpbin/headers?host:
     status: 200
     timeout: 60000

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -204,7 +204,7 @@ http:
     request-headers:
       - "Foo: bar"
     headers: ["Content-Type: application/json"]
-    body: ['"Foo": "bar"', '"user-agent": "goss/0.0.0"']
+    body: ['"Foo": "bar"']
   http://httpbin/headers?host:
     status: 200
     timeout: 60000

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -204,7 +204,9 @@ http:
     request-headers:
       - "Foo: bar"
     headers: ["Content-Type: application/json"]
-    body: ['"Foo": "bar"']
+    body:
+      - '"Foo": "bar"'
+      - '"User-Agent": "goss/0.0.0"'
   http://httpbin/headers?host:
     status: 200
     timeout: 60000

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -204,12 +204,9 @@ http:
     request-headers:
       - "Foo: bar"
     headers: ["Content-Type: application/json"]
-    body: ['"Foo": "bar"']
-  http://httpbin/headers:
-    status: 200
-    timeout: 60000
-    headers: ["Content-Type: application/json"]
-    body: ['"User-Agent": "goss']
+    body:
+      - '"Foo": "bar"'
+      - '"user-agent": "goss/0.0.0"'
   http://httpbin/headers?host:
     status: 200
     timeout: 60000

--- a/release-build.sh
+++ b/release-build.sh
@@ -22,7 +22,7 @@ fi
 output="${output_dir}/${output_fname}"
 
 GOOS="${os}" GOARCH="${arch}" CGO_ENABLED=0 go build \
-  -ldflags "-X main.version=${version_stamp} -s -w" \
+  -ldflags "-X main.version=${version_stamp} -X github.com/goss-org/goss/util.Version=${version_stamp} -s -w" \
   -o "${output}" \
   github.com/goss-org/goss/cmd/goss
 

--- a/release-build.sh
+++ b/release-build.sh
@@ -22,7 +22,7 @@ fi
 output="${output_dir}/${output_fname}"
 
 GOOS="${os}" GOARCH="${arch}" CGO_ENABLED=0 go build \
-  -ldflags "-X main.version=${version_stamp} -X github.com/goss-org/goss/util.Version=${version_stamp} -s -w" \
+  -ldflags "-X github.com/goss-org/goss/util.Version=${version_stamp} -s -w" \
   -o "${output}" \
   github.com/goss-org/goss/cmd/goss
 

--- a/system/http.go
+++ b/system/http.go
@@ -220,7 +220,7 @@ func (u *DefHTTP) Body() (io.Reader, error) {
 
 func hasUserAgentHeader(headers []string) bool {
 	for _, header := range headers {
-		if strings.HasPrefix(header, USER_AGENT_HEADER_PREFIX) {
+		if strings.HasPrefix(strings.ToLower(header), USER_AGENT_HEADER_PREFIX) {
 			return true
 		}
 	}

--- a/system/http.go
+++ b/system/http.go
@@ -16,6 +16,9 @@ import (
 	"github.com/goss-org/goss/util"
 )
 
+const USER_AGENT_HEADER_PREFIX = "user-agent:"
+const DEFAULT_USER_AGENT = "goss/x.x.x"
+
 type HTTP interface {
 	HTTP() string
 	Status() (int, error)
@@ -47,6 +50,11 @@ type DefHTTP struct {
 
 func NewDefHTTP(_ context.Context, httpStr string, system *System, config util.Config) HTTP {
 	headers := http.Header{}
+
+	if !hasUserAgentHeader(config.RequestHeader) {
+		config.RequestHeader = append(config.RequestHeader, fmt.Sprintf("%s %s", USER_AGENT_HEADER_PREFIX, DEFAULT_USER_AGENT))
+	}
+
 	for _, r := range config.RequestHeader {
 		str := strings.SplitN(r, ": ", 2)
 		headers.Add(str[0], str[1])
@@ -208,4 +216,13 @@ func (u *DefHTTP) Body() (io.Reader, error) {
 	}
 
 	return u.resp.Body, nil
+}
+
+func hasUserAgentHeader(headers []string) bool {
+	for _, header := range headers {
+		if strings.HasPrefix(header, USER_AGENT_HEADER_PREFIX) {
+			return true
+		}
+	}
+	return false
 }

--- a/system/http.go
+++ b/system/http.go
@@ -17,7 +17,7 @@ import (
 )
 
 const USER_AGENT_HEADER_PREFIX = "user-agent:"
-const DEFAULT_USER_AGENT = "goss/x.x.x"
+const DEFAULT_USER_AGENT_PREFIX = "goss/"
 
 type HTTP interface {
 	HTTP() string
@@ -52,7 +52,7 @@ func NewDefHTTP(_ context.Context, httpStr string, system *System, config util.C
 	headers := http.Header{}
 
 	if !hasUserAgentHeader(config.RequestHeader) {
-		config.RequestHeader = append(config.RequestHeader, fmt.Sprintf("%s %s", USER_AGENT_HEADER_PREFIX, DEFAULT_USER_AGENT))
+		config.RequestHeader = append(config.RequestHeader, fmt.Sprintf("%s %s%s", USER_AGENT_HEADER_PREFIX, DEFAULT_USER_AGENT_PREFIX, util.Version))
 	}
 
 	for _, r := range config.RequestHeader {

--- a/util/build.go
+++ b/util/build.go
@@ -1,0 +1,3 @@
+package util
+
+var Version string


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
Close #882. Adding default user-agent header by detecting if a user-agent header was given in the `request_headers` field in the goss file and defaulting to `goss/x.x.x`. Any guidance that can be given on how to get the current  version of goss within the codebase would be appreciated. I saw app.Version but that seemed to be related to urfave/cli so wasn't sure I could get that from that far down. The easiest way is probably adding it to the context but I didn't want to bloat that since it would go to all checks not just http.