### PR TITLE
s/during during/during/

### DIFF
--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -907,7 +907,7 @@ Available functions:
     `readFile "fileName"`
     :   Reads file content into a string, trims whitespace. Useful when a file contains a token.
         !!! note
-            Goss will error out during during the parsing phase if the file does not exist, no tests will be executed.
+            Goss will error out during the parsing phase if the file does not exist, no tests will be executed.
 
     `regexMatch "(some)?reg[eE]xp"`
     :   Tests the piped input against the regular expression argument.


### PR DESCRIPTION
- [x] `make test-all` (UNIX) passes. CI will also test this

### Description of change

Just replace "during during" from documentation.