### PR TITLE
regexFirstGroup return first group from regexp, useful with .env file…

### DIFF
--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -918,10 +918,29 @@ Available functions:
     `toUpper`
     :   Changes piped input to UPPERCASE
 
+       
     `findStringSubmatch regex string`
-    :   Returns the n group from regex. For example:
-        `{{ $findStr := findStringSubmatch "([a-z0-9+]):([a-z0-9+])@localhost\/([a-z0-9+])" "my $conf_bd = 'mysql://userBD01:passBD01@localhost/db01'" }}`
-        `{{ $USER := index $findStr 1 }}{{ $PASS := index $findStr 2 }}  {{ $BD := index $findStr 3 }}`
+    :   Returns map[string]interface{} with the names of the parenthesized subexpressions, like `(?P<first>[a-z])`
+        
+        {{ $regexDBrc := "\\'mysql:\\/\\/(?P<login>[a-z0-9]+):(?P<password>[a-z0-9]+)@localhost\\/(?P<database>roundcube_[a-z0-9]+)\\';"}}
+        
+        {{ $rcConf := readFile /home/user/roundcube/config.inc.php | findStringSubmatch $regexDBrc }}
+        {{ $UserDBrc := get $rcConf "login" }}
+        {{ $PassDBrc  := get $rcConf "password" }}
+        {{ $DBrc := get $rcConf "database" }}
+
+    If not exists named parenthesized subexps, returns stringfied array string:
+
+        {{ $regexDBrc := "\\'mysql:\\/\\/([a-z0-9]+):([a-z0-9]+)@localhost\\/(roundcube_[a-z0-9]+)\\';"}}
+        
+        {{ $rcConf := readFile /home/user/roundcube/config.inc.php | findStringSubmatch $regexDBrc }}
+        {{ $UserDBrc := get $rcConf "1" }}
+        {{ $PassDBrc  := get $rcConf "2" }}
+        {{ $DBrc := get $rcConf "3" }}
+
+    NOTE: stringfied string array begins with "1" ("0" is all the string matched)
+
+        
 
 
 !!! warning

--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -918,6 +918,15 @@ Available functions:
     `toUpper`
     :   Changes piped input to UPPERCASE
 
+    `regexFirstGroup "my $conf_bd = '(mysql://user:pass@localhost/db)'"`
+    :   Returns the first group from regexp, for example config to connect mysql. Useful with `readFile FILE | regexFirstGroup REGEXP`
+
+```go
+{{ $regexBDRC := "\\'mysql:\\/\\/[a-z0-9]+:[a-z0-9]+@localhost\\/([a-z0-9]+)\\';"}}
+{{ $BD := readFile $fileRCConfig | regexFirstGroup $regexBD}}
+```
+
+
 !!! warning
 
     gossfiles containing text/template `{{}}` controls will no longer work with `goss add/autoadd`.

--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -918,13 +918,10 @@ Available functions:
     `toUpper`
     :   Changes piped input to UPPERCASE
 
-    `regexFirstGroup "my $conf_bd = '(mysql://user:pass@localhost/db)'"`
-    :   Returns the first group from regexp, for example config to connect mysql. Useful with `readFile FILE | regexFirstGroup REGEXP`
-
-```go
-{{ $regexBDRC := "\\'mysql:\\/\\/[a-z0-9]+:[a-z0-9]+@localhost\\/([a-z0-9]+)\\';"}}
-{{ $BD := readFile $fileRCConfig | regexFirstGroup $regexBD}}
-```
+    `findStringSubmatch regex string`
+    :   Returns the n group from regex. For example:
+        `{{ $findStr := findStringSubmatch "([a-z0-9+]):([a-z0-9+])@localhost\/([a-z0-9+])" "my $conf_bd = 'mysql://userBD01:passBD01@localhost/db01'" }}`
+        `{{ $USER := index $findStr 1 }}{{ $PASS := index $findStr 2 }}  {{ $BD := index $findStr 3 }}`
 
 
 !!! warning

--- a/template.go
+++ b/template.go
@@ -76,27 +76,18 @@ func regexMatch(re, s string) (bool, error) {
 	return compiled.MatchString(s), nil
 }
 
-// return first group from regexp
-func regexFirstGroup(re, s string) string {
-	compiled, err := regexp.Compile(re)
-	if err != nil {
-		return ""
-	}
-
-	if compiled.MatchString(s) {
-		// second match (first match is all the text)
-		return compiled.FindAllStringSubmatch(s, -1)[0][1]
-	}
-
-	return ""
+// return submatchs from string, see https://github.com/goss-org/goss/pull/895#pullrequestreview-2017498865 by @aelsabbahy
+func findStringSubmatch(pattern, input string) []string {
+	re := regexp.MustCompile(pattern)
+	return re.FindStringSubmatch(input)
 }
 
 var funcMap = template.FuncMap{
-	"mkSlice":         mkSlice,
-	"readFile":        readFile,
-	"getEnv":          getEnv,
-	"regexMatch":      regexMatch,
-	"toUpper":         strings.ToUpper,
-	"toLower":         strings.ToLower,
-	"regexFirstGroup": regexFirstGroup,
+	"mkSlice":            mkSlice,
+	"readFile":           readFile,
+	"getEnv":             getEnv,
+	"regexMatch":         regexMatch,
+	"toUpper":            strings.ToUpper,
+	"toLower":            strings.ToLower,
+	"findStringSubmatch": findStringSubmatch,
 }

--- a/template.go
+++ b/template.go
@@ -76,11 +76,27 @@ func regexMatch(re, s string) (bool, error) {
 	return compiled.MatchString(s), nil
 }
 
+// return first group from regexp
+func regexFirstGroup(re, s string) string {
+	compiled, err := regexp.Compile(re)
+	if err != nil {
+		return ""
+	}
+
+	if compiled.MatchString(s) {
+		// second match (first match is all the text)
+		return compiled.FindAllStringSubmatch(s, -1)[0][1]
+	}
+
+	return ""
+}
+
 var funcMap = template.FuncMap{
-	"mkSlice":    mkSlice,
-	"readFile":   readFile,
-	"getEnv":     getEnv,
-	"regexMatch": regexMatch,
-	"toUpper":    strings.ToUpper,
-	"toLower":    strings.ToLower,
+	"mkSlice":         mkSlice,
+	"readFile":        readFile,
+	"getEnv":          getEnv,
+	"regexMatch":      regexMatch,
+	"toUpper":         strings.ToUpper,
+	"toLower":         strings.ToLower,
+	"regexFirstGroup": regexFirstGroup,
 }


### PR DESCRIPTION
…s and another config files.

From my server I need to access config.inc.php file to know user, password and BD to execute a mysql command to check data using "command" resource. Also can use with .env files or similar.

Example:

{{ $regexBDRC := "\\'mysql:\\/\\/[a-z0-9]+:[a-z0-9]+@localhost\\/(roundcube[a-z0-9]+)\\';"}}
{{ $BDRC := readFile $fileRCConfig | regexFirstGroup $regexBDRC}}

Extract BD (first group from regexp) from Roundcube config, to check table "users" with something like that:

command:
  'mysql RC':
    exit-status: 0
    exec: {{ print "mysql -u " $UserBDRC " -p" $PassBDRC " " $BDRC " -e 'select user_id from users limit 1' --skip-column-names" }}
    stdout:
      and:
      - 1
    stderr: []
    timeout: 10000 # in milliseconds
    skip: false


##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)


### Description of change

I just modified template to add func regexFirstGroup only. I checked on my own docker image with success.
