### PR TITLE
Add new runtime environment variable to dgoss to copy additional files

### DIFF
--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -96,6 +96,17 @@ Time to sleep after running container (and optionally `goss_wait.yaml`) and befo
 
 Location of the goss yaml files. (Default: `.`)
 
+#### GOSS_ADDITIONAL_COPY_PATH
+
+Colon-seperated list of additional directories to copy to container.
+
+By default dgoss copies `goss.yaml` from the current working directory and
+nothing else. You may need other files like scripts and configurations copied
+as well. Specify `GOSS_ADDITIONAL_COPY_PATH` similar to `$PATH` as colon seperated
+list of directories for each additional directory you'd like to recursively copy.
+These will be copied as directories next to `goss.yaml` in the temporary
+directory `DGOSS_TEMP_DIR`. (Default: `''`)
+
 #### GOSS_VARS
 
 The name of the variables file relative to `GOSS_FILES_PATH` to copy into the

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -33,9 +33,16 @@ run(){
     # Copy in goss
     cp "${GOSS_PATH}" "$tmp_dir/goss"
     chmod 755 "$tmp_dir/goss"
+
     [[ -e "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" "$tmp_dir/goss.yaml" && chmod 644 "$tmp_dir/goss.yaml"
     [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir" && chmod 644 "$tmp_dir/goss_wait.yaml"
     [[ -n "${GOSS_VARS}" ]] && [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_VARS}" "$tmp_dir" && chmod 644 "$tmp_dir/${GOSS_VARS}"
+    if [ -n "$GOSS_ADDITIONAL_COPY_PATH" ]; then
+        for dir in "$(echo "$GOSS_ADDITIONAL_COPY_PATH" | sed 's/:/ /g')"; do
+            cp -r ${dir} "${tmp_dir}/"
+            chmod -R 755 "$tmp_dir/$(basename ${dir})"
+        done
+    fi
 
     # Switch between mount or cp files strategy
     GOSS_FILES_STRATEGY=${GOSS_FILES_STRATEGY:="mount"}

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -33,7 +33,6 @@ run(){
     # Copy in goss
     cp "${GOSS_PATH}" "$tmp_dir/goss"
     chmod 755 "$tmp_dir/goss"
-
     [[ -e "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_FILE:-goss.yaml}" "$tmp_dir/goss.yaml" && chmod 644 "$tmp_dir/goss.yaml"
     [[ -e "${GOSS_FILES_PATH}/goss_wait.yaml" ]] && cp "${GOSS_FILES_PATH}/goss_wait.yaml" "$tmp_dir" && chmod 644 "$tmp_dir/goss_wait.yaml"
     [[ -n "${GOSS_VARS}" ]] && [[ -e "${GOSS_FILES_PATH}/${GOSS_VARS}" ]] && cp "${GOSS_FILES_PATH}/${GOSS_VARS}" "$tmp_dir" && chmod 644 "$tmp_dir/${GOSS_VARS}"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

Fixes:
- #896

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Allows you to use or copy additional files in the container with the help of new env var `GOSS_ADDITIONAL_COPY_PATH` in `dgoss` in order to set up tests hierarchically with `gossfile`.


<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--898.org.readthedocs.build/en/898/

<!-- readthedocs-preview goss end -->