### PR TITLE
fix path pattern in documentation pipeline

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - mkdocs.yml
-      - docs/
+      - docs/**
       - README.md
       - LICENSE
       - extras/**/README.md

--- a/.github/workflows/preview-docs.yaml
+++ b/.github/workflows/preview-docs.yaml
@@ -5,7 +5,7 @@ on:
       - opened
     paths:
       - mkdocs.yml
-      - docs/
+      - docs/**
       - README.md
       - LICENSE
       - extras/**/README.md


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

IMHO there is an error in the path pattern in the documentation pipeline.
The pipeline should run at any changes in `docs` folder. But the PR #917 and #918 show that is not the case.
But there should be a preview, especially for changes to the requirements.txt.

I was also able to reproduce this in a test.

Docs:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-and-excluding-paths
- https://github.com/readthedocs/actions/tree/v1/preview#how-to-use-it


After a merge #917 and #918 should be rebased.
