### PR TITLE
fix link to codeclimate in docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,14 +81,14 @@ markdown_extensions:
       check_paths: true
   - pymdownx.superfences
 
-copyright: Copyright &copy; 2015 - 2023 Ahmed Elsabbahy
+copyright: Copyright &copy; 2015 - 2024 Ahmed Elsabbahy
 
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/gooss-org/goss
+      link: https://github.com/goss-org/goss
     - icon: simple/codeclimate
-      link: https://codeclimate.com/github/goss-org/goss
+      link: https://codeclimate.com/github/aelsabbahy/goss
     - icon: simple/travisci
       link: https://travis-ci.org/goss-org/goss
     - icon: fontawesome/brands/medium


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

- Fix xopyright year
- typo in github link
- path to codeclimate project

<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--926.org.readthedocs.build/en/926/

<!-- readthedocs-preview goss end -->