### PR TITLE
disable deprecated codeclimate plugin golint

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -6,8 +6,6 @@ checks:
 plugins:
   gofmt:
     enabled: true
-  golint:
-    enabled: true
   govet:
     enabled: true
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

- The plugin is deprecated: https://docs.codeclimate.com/docs/golint
- And it reports errors: https://codeclimate.com/github/aelsabbahy/goss/builds/693

I have not seen an alternative for this plugin.

Reported error/line:
https://github.com/goss-org/goss/blob/6a8fc9623d846e4b9093fde7f9685e6abcc21457/goss_config.go#L114
