### PR TITLE
fix integration tests for alpine3

### DIFF
--- a/integration-tests/Dockerfile_alpine3
+++ b/integration-tests/Dockerfile_alpine3
@@ -4,6 +4,7 @@ MAINTAINER Ahmed
 # install apache2 and remove un-needed services
 RUN apk update && \
   apk add --no-cache openrc apache2=2.4.59-r0 bash ca-certificates tinyproxy && \
+  sed -i 's/Listen 80/Listen 0.0.0.0:80/g' /etc/apache2/httpd.conf && \
   rc-update add apache2 && \
   rc-update add tinyproxy && \
   rm -rf /etc/init.d/networking /etc/init.d/hwdrivers /var/cache/apk/* /tmp/*


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Apache2 has only one listener by design. Either IPv4 or IPv6. 

It seems that the order of the ip addresses has been changed (in CI/docker runtime). Previously IPv4 first to now IPv6 first. If the test with Apache2 should explicitly test IPv4, the service should also explicitly run on IPv4.

Related:
- #935 
- #936 
- #907 