### PR TITLE
Replace deprecated MAINTAINER with LABEL in Dockerfiles

### DIFF
--- a/integration-tests/Dockerfile_alpine3
+++ b/integration-tests/Dockerfile_alpine3
@@ -1,5 +1,5 @@
 FROM alpine:3.19
-MAINTAINER Ahmed
+LABEL org.opencontainers.image.authors="Ahmed"
 
 # install apache2 and remove un-needed services
 RUN apk update && \

--- a/integration-tests/Dockerfile_alpine3.md5
+++ b/integration-tests/Dockerfile_alpine3.md5
@@ -1,1 +1,1 @@
-f9c8c187e94693c4625a8c8d01fae3bf  Dockerfile_alpine3
+3c4e7fbf89cd2edfeae94728e247213d  Dockerfile_alpine3

--- a/integration-tests/Dockerfile_centos7
+++ b/integration-tests/Dockerfile_centos7
@@ -1,5 +1,5 @@
 FROM centos:7.2.1511
-MAINTAINER Ahmed
+LABEL org.opencontainers.image.authors="Ahmed"
 
 ENV container docker
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \

--- a/integration-tests/Dockerfile_centos7.md5
+++ b/integration-tests/Dockerfile_centos7.md5
@@ -1,1 +1,1 @@
-c23a345162d68af38d754ebc7233be35  Dockerfile_centos7
+148b069bc0a023068cbcdfe8b24fe036  Dockerfile_centos7

--- a/integration-tests/Dockerfile_centos7.md5
+++ b/integration-tests/Dockerfile_centos7.md5
@@ -1,1 +1,1 @@
-1f7064dbc55b5c3e1fbb23f2e6457a13  Dockerfile_centos7
+c23a345162d68af38d754ebc7233be35  Dockerfile_centos7

--- a/integration-tests/Dockerfile_trusty
+++ b/integration-tests/Dockerfile_trusty
@@ -1,5 +1,5 @@
 FROM ubuntu-upstart:trusty
-MAINTAINER Ahmed
+LABEL org.opencontainers.image.authors="Ahmed"
 
 RUN apt-get update && \
     apt-get install -y apache2=2.4.7-1ubuntu4.22 tinyproxy && \

--- a/integration-tests/Dockerfile_trusty.md5
+++ b/integration-tests/Dockerfile_trusty.md5
@@ -1,1 +1,1 @@
-b7ef9dc0d9c6b00f6997fb25e3a19451  Dockerfile_trusty
+9db0e607ec52f1fd1290785721733180  Dockerfile_trusty

--- a/integration-tests/Dockerfile_trusty.md5
+++ b/integration-tests/Dockerfile_trusty.md5
@@ -1,1 +1,1 @@
-ac8c8df3415c0eecdbedc322480e696e  Dockerfile_trusty
+b7ef9dc0d9c6b00f6997fb25e3a19451  Dockerfile_trusty

--- a/integration-tests/Dockerfile_wheezy
+++ b/integration-tests/Dockerfile_wheezy
@@ -1,5 +1,5 @@
 FROM debian:wheezy
-MAINTAINER Ahmed
+LABEL org.opencontainers.image.authors="Ahmed"
 
 RUN echo 'deb http://archive.debian.org/debian wheezy main' > /etc/apt/sources.list
 RUN echo 'deb http://archive.debian.org/debian-security wheezy/updates main' >> /etc/apt/sources.list

--- a/integration-tests/Dockerfile_wheezy.md5
+++ b/integration-tests/Dockerfile_wheezy.md5
@@ -1,1 +1,1 @@
-485a260105b0f1da058fa4af863e2ecc  Dockerfile_wheezy
+da725462c09b35ccf7759080ed5e8059  Dockerfile_wheezy

--- a/integration-tests/Dockerfile_wheezy.md5
+++ b/integration-tests/Dockerfile_wheezy.md5
@@ -1,1 +1,1 @@
-da725462c09b35ccf7759080ed5e8059  Dockerfile_wheezy
+557a19e04e66f0a9afb6035952b5ca18  Dockerfile_wheezy


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

MAINTAINER is deprecated: https://docs.docker.com/reference/dockerfile/#maintainer-deprecated

Replacing md5 sums because it is no major change to rebuild images.

Related to:
- #948 