### PR TITLE
fix(ci): rework get latest tag for build Docker image

### DIFF
--- a/.github/workflows/docker-goss.yaml
+++ b/.github/workflows/docker-goss.yaml
@@ -45,10 +45,20 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/goss
 
       - name: Get latest git tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
+        if: github.ref_name == 'master'
         id: get-latest-tag
+        run: |
+          # source: https://github.com/actions-ecosystem/action-get-latest-tag/blob/main/entrypoint.sh
+          set -e
+          git config --global --add safe.directory /github/workspace
+          git fetch --tags --force
+          # This suppress an error occurred when the repository is a complete one.
+          git fetch --prune --unshallow 2>/dev/null || true
+          latest_tag=$(git describe --abbrev=0 --tags || true)
+          echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Set short git commit SHA
+        if: github.ref_name == 'master'
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV

--- a/.github/workflows/docker-goss.yaml
+++ b/.github/workflows/docker-goss.yaml
@@ -56,12 +56,14 @@ jobs:
           git fetch --prune --unshallow 2>/dev/null || true
           latest_tag=$(git describe --abbrev=0 --tags || true)
           echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+          echo "Latest tag: $tag"
 
       - name: Set short git commit SHA
         if: github.ref_name == 'master'
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+          echo "COMMIT_SHORT_SHA: $COMMIT_SHORT_SHA"
 
       - name: Get the current version of Go from project.
         run: echo "GO_VERSION_FROM_PROJECT=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV

--- a/.github/workflows/docker-goss.yaml
+++ b/.github/workflows/docker-goss.yaml
@@ -56,14 +56,14 @@ jobs:
           git fetch --prune --unshallow 2>/dev/null || true
           latest_tag=$(git describe --abbrev=0 --tags || true)
           echo "tag=${latest_tag}" >> "$GITHUB_OUTPUT"
-          echo "Latest tag: $tag"
+          echo "Latest tag: $latest_tag"
 
       - name: Set short git commit SHA
         if: github.ref_name == 'master'
         run: |
           calculatedSha=$(git rev-parse --short ${{ github.sha }})
           echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
-          echo "COMMIT_SHORT_SHA: $COMMIT_SHORT_SHA"
+          echo "COMMIT_SHORT_SHA: $calculatedSha"
 
       - name: Get the current version of Go from project.
         run: echo "GO_VERSION_FROM_PROJECT=$(go mod edit -json | jq -r .Go)" >> $GITHUB_ENV


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

I have seen that building the Docker image had failed: https://github.com/goss-org/goss/actions/runs/9982852891/job/27589357250

Reason is a not fixed upstream bug. https://github.com/actions-ecosystem/action-get-latest-tag/pull/22
I was not able to reproduce this in my fork.

I have reworked this part of CI:
- only run to get the tag if required
- remove the dependency. this does not seem to be well maintained
- apply the fix from the PR
 
