### PR TITLE
Fixed: the user-agent test on release builds

### DIFF
--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -206,7 +206,7 @@ http:
     headers: ["Content-Type: application/json"]
     body:
       - '"Foo": "bar"'
-      - '"User-Agent": "goss/0.0.0"'
+      - '/"User-Agent": "goss/[0-9]+.[0-9]+.[0-9]+"/'
   http://httpbin/headers?host:
     status: 200
     timeout: 60000


### PR DESCRIPTION
The user-agent test assumed goss will always have v0.0.0, this is not the case in a release build.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Fixes release builds.