### PR TITLE
docs: fix links to documentation (https://goss.readthedocs.io) and bump version examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ make build
 
 ## Full Documentation
 
-[Full Documentation](https://github.com/goss-org/goss/blob/e73553f9c3065ac297499dafb4f8abef6acb24ad/docs/manual.md)
+[Full Documentation](https://goss.readthedocs.io/en/stable/)
 
 ## Using the container image
 
-[Using the Goss container image](docs/container_image.md)
+[Using the Goss container image](https://goss.readthedocs.io/en/stable/container_image/)
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ This will install goss and [dgoss](https://github.com/goss-org/goss/tree/master/
 # Install latest version to /usr/local/bin
 curl -fsSL https://goss.rocks/install | sh
 
-# Install v0.3.16 version to ~/bin
-curl -fsSL https://goss.rocks/install | GOSS_VER=v0.3.16 GOSS_DST=~/bin sh
+# Install v0.4.8 version to ~/bin
+curl -fsSL https://goss.rocks/install | GOSS_VER=v0.4.8 GOSS_DST=~/bin sh
 ```
 
 <!-- --8<-- [end:intro] -->

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ chmod +rx /usr/local/bin/dgoss
 
 ```bash
 # See https://github.com/goss-org/goss/releases for release versions
-VERSION=v0.3.10
+VERSION=v0.4.8
 curl -L "https://github.com/goss-org/goss/releases/download/${VERSION}/goss-linux-amd64" -o /usr/local/bin/goss
 chmod +rx /usr/local/bin/goss
 
 # (optional) dgoss docker wrapper (use 'master' for latest version)
-VERSION=v0.3.10
+VERSION=v0.4.8
 curl -L "https://github.com/goss-org/goss/releases/download/${VERSION}/dgoss" -o /usr/local/bin/dgoss
 chmod +rx /usr/local/bin/dgoss
 ```

--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -25,8 +25,8 @@ Since goss runs on the target container, dgoss can be used on a Mac OSX system b
 curl -L https://raw.githubusercontent.com/goss-org/goss/master/extras/dgoss/dgoss -o /usr/local/bin/dgoss
 chmod +rx /usr/local/bin/dgoss
 
-# Download desired goss version to your preferred location (e.g. v0.3.6)
-curl -L https://github.com/goss-org/goss/releases/download/v0.3.6/goss-linux-amd64 -o ~/Downloads/goss-linux-amd64
+# Download desired goss version to your preferred location (e.g. v0.4.8)
+curl -L https://github.com/goss-org/goss/releases/download/v0.4.8/goss-linux-amd64 -o ~/Downloads/goss-linux-amd64
 
 # Set your GOSS_PATH to the above location
 export GOSS_PATH=~/Downloads/goss-linux-amd64

--- a/extras/kgoss/README.md
+++ b/extras/kgoss/README.md
@@ -59,7 +59,7 @@ chmod a+rx "${dest_dir}/kgoss"
 
 ## install goss
 if [[ ! $(which jq) ]]; then echo "jq is required, get from https://stedolan.github.io/jq"; fi
-version=v0.3.8
+version=v0.4.8
 arch=amd64
 host=github.com
 # for private repos, leave `host` blank or same as above:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

I have not adjusted the links that point to https://goss.rocks. These may need to be adjusted if the http redirect is active.


<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--958.org.readthedocs.build/en/958/

<!-- readthedocs-preview goss end -->