### PR TITLE
ci: bump httpd in rockylinux9

### DIFF
--- a/integration-tests/goss/rockylinux9/goss-aa-expected.yaml
+++ b/integration-tests/goss/rockylinux9/goss-aa-expected.yaml
@@ -2,7 +2,7 @@ package:
   httpd:
     installed: true
     versions:
-    - 2.4.57-8.el9
+    - 2.4.57-11.el9_4
 port:
   tcp:80:
     listening: true

--- a/integration-tests/goss/rockylinux9/goss-expected.yaml
+++ b/integration-tests/goss/rockylinux9/goss-expected.yaml
@@ -15,7 +15,7 @@ package:
   httpd:
     installed: true
     versions:
-    - 2.4.57-8.el9
+    - 2.4.57-11.el9_4
   vim-tiny:
     installed: false
 addr:

--- a/integration-tests/goss/vars.yaml
+++ b/integration-tests/goss/vars.yaml
@@ -16,7 +16,7 @@ centos7:
 rockylinux9:
   proxy: http://127.0.0.1:8888
   packages:
-    httpd: "2.4.57-8.el9"
+    httpd: "2.4.57-11.el9_4"
   services:
     httpd: []
 trusty:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

This is just a kind of workaround. I think the image needs to be frozen or the version number check needs to be changed. Rockylinux only has one version of `httpd` in the repository. So it can't be fixed.