### PR TITLE
add md5 checksum of dockerfiles to image labels

### DIFF
--- a/.github/workflows/docker-integration-tests.yaml
+++ b/.github/workflows/docker-integration-tests.yaml
@@ -61,12 +61,19 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: MD5 of Dockerfile
+        id: md5_result
+        run: |
+          echo "md5=$(md5sum "${{ matrix.dockerfile }}" | awk '{ print $1 }')" >> $GITHUB_OUTPUT
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          labels: |
+            rocks.goss.dockerfile-md5=${{ steps.md5_result.outputs.md5 }}
 
       - name: Build and push tag
         uses: docker/build-push-action@v5

--- a/development/build_images.sh
+++ b/development/build_images.sh
@@ -12,6 +12,7 @@ LABEL_REVISION=$(git rev-parse HEAD)
 for docker_file in $INTEGRATION_TEST_DIR/Dockerfile_*; do
     [[ $docker_file == *.md5 ]] && continue
     os=$(cut -d '_' -f2 <<<"$docker_file")
+    md5=$(md5sum "$docker_file" | awk '{ print $1 }')
     docker build \
         --label "org.opencontainers.image.created=$LABEL_DATE" \
         --label "org.opencontainers.image.description=Quick and Easy server testing/validation" \
@@ -21,5 +22,6 @@ for docker_file in $INTEGRATION_TEST_DIR/Dockerfile_*; do
         --label "org.opencontainers.image.title=goss" \
         --label "org.opencontainers.image.url=$LABEL_URL" \
         --label "org.opencontainers.image.version=manual" \
+        --label "rocks.goss.dockerfile-md5"=$md5 \
         -t "aelsabbahy/goss_${os}:latest" - < "$docker_file"
 done


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->
Add m5 checksums to a an image label.
This can be directly compared later and is also available in the image in the long term.
