### PR TITLE
fix(dgoss): edgecase where no log is written

### DIFF
--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -20,6 +20,8 @@ cleanup() {
     set +e
     { kill "$log_pid" && wait "$log_pid"; } 2> /dev/null
     if [ -n "$CONTAINER_LOG_OUTPUT" ]; then
+        info "Stopping container and copy log"
+        $CONTAINER_RUNTIME stop "$id" > /dev/null
         cp "$tmp_dir/docker_output.log" "$CONTAINER_LOG_OUTPUT"
     fi
     rm -rf "$tmp_dir"
@@ -66,6 +68,8 @@ run(){
     esac
 
     $CONTAINER_RUNTIME logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
+    # There is a chance that the log will not be written, an empty line is added for mitigation.
+    echo "" >> "$tmp_dir/docker_output.log" 2>&1 &
     log_pid=$!
     info "Container ID: ${id:0:8}"
 }

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -18,14 +18,20 @@ error() {
 
 cleanup() {
     set +e
+    # There is a chance that the log will not be written completely.
+    # Exit the container and retrieve the last line of logs to ensure
+    # that all logs have been read.
+    info "Stopping container"
+    $CONTAINER_RUNTIME stop --time 1 "$id" > /dev/null 2>&1
+    $CONTAINER_RUNTIME logs --tail 1 "$id" > /dev/null 2>&1
+
     { kill "$log_pid" && wait "$log_pid"; } 2> /dev/null
     if [ -n "$CONTAINER_LOG_OUTPUT" ]; then
-        info "Stopping container and copy log"
-        $CONTAINER_RUNTIME stop -t 1 "$id" > /dev/null
+        info "Copying log"
         cp "$tmp_dir/docker_output.log" "$CONTAINER_LOG_OUTPUT"
     fi
     rm -rf "$tmp_dir"
-    if [[ $id ]];then
+    if [[ $id ]]; then
         info "Deleting container"
         $CONTAINER_RUNTIME rm -vf "$id" > /dev/null
     fi
@@ -68,8 +74,6 @@ run(){
     esac
 
     $CONTAINER_RUNTIME logs -f "$id" > "$tmp_dir/docker_output.log" 2>&1 &
-    # There is a chance that the log will not be written, an empty line is added for mitigation.
-    echo "" >> "$tmp_dir/docker_output.log" 2>&1 &
     log_pid=$!
     info "Container ID: ${id:0:8}"
 }

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -21,7 +21,7 @@ cleanup() {
     { kill "$log_pid" && wait "$log_pid"; } 2> /dev/null
     if [ -n "$CONTAINER_LOG_OUTPUT" ]; then
         info "Stopping container and copy log"
-        $CONTAINER_RUNTIME stop "$id" > /dev/null
+        $CONTAINER_RUNTIME stop -t 1 "$id" > /dev/null
         cp "$tmp_dir/docker_output.log" "$CONTAINER_LOG_OUTPUT"
     fi
     rm -rf "$tmp_dir"


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

I think this is a bug or a edge case. I used `podman` and always got an empty log file.
Partly it is discribed: https://docs.podman.io/en/stable/markdown/podman-logs.1.html#follow-f

> **--follow, -f**
> Follow log output. Default is false.
>
> Note: When following a container which is removed by podman container rm or removed on exit (podman run --rm ...), there is a chance that the log file is removed before podman logs reads the final content.

I'm not sure if it's related to this or a problem with the flushing of the pipe in the operating system.

If the container is stopped before removal and a second pipe is created, the log is written. The content of the second pipe does not arrive and is therefore presumably swallowed.

If I am set timeout to `0` (`$CONTAINER_RUNTIME stop -t 0 "$id" > /dev/null`) then the last log entry appears in the log file in the tmp directory, but is apparently written to late and not copied to the target file.