### PR TITLE
dgoss: add flag for debugging

### DIFF
--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -80,6 +80,21 @@ This allows the user to leverage the `goss add|autoadd` commands to write tests 
 
 The following environment variables can be set to change the behavior of dgoss.
 
+#### DEBUG
+
+Enables debug output of `dgoss`.
+
+When running in debug mode, the tmp dir with the container output will not be cleaned up.
+
+Note: Debug output of `dgoss` is from `dgoss` shell script and not debug output of `goss`
+(`dgoss run -e GOSS_LOGLEVEL=DEBUG jenkins:alpine`).
+
+**Default:** empty
+
+**Example:**
+
+`DEBUG=true dgoss run jenkins:alpine`
+
 #### GOSS_PATH
 
 Location of the goss binary to use. (Default: `$(which goss)`)

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+[ "$DEBUG" ] && set -x
 
 USAGE="USAGE: $(basename "$0") [run|edit] <docker_run_params>"
 GOSS_FILES_PATH="${GOSS_FILES_PATH:-.}"
@@ -22,7 +23,7 @@ cleanup() {
     if [ -n "$CONTAINER_LOG_OUTPUT" ]; then
         cp "$tmp_dir/docker_output.log" "$CONTAINER_LOG_OUTPUT"
     fi
-    rm -rf "$tmp_dir"
+    [ "$DEBUG" ] || rm -rf "$tmp_dir"
     if [[ $id ]];then
         info "Deleting container"
         $CONTAINER_RUNTIME rm -vf "$id" > /dev/null


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Enables debugging of dgoss. The feature is already part of dcgoss.


<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--998.org.readthedocs.build/en/998/

<!-- readthedocs-preview goss end -->