### PR TITLE
Add SSHFP record lookups

### DIFF
--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -205,6 +205,7 @@ It is possible to validate the following types of DNS records, but requires the 
 * `NS`
 * `PTR`
 * `SRV`
+* `SSHFP`
 * `TXT`
 
 To validate specific DNS address types, prepend the hostname with the type and a colon, a few examples:
@@ -225,13 +226,25 @@ dns:
     addrs:
     - "dns.google."
 
-  # Validate and SRV record
+  # Validate a SRV record
   SRV:_https._tcp.dnstest.io:
     resolvable: true
     server: 208.67.222.222
     addrs:
     - "0 5 443 a.dnstest.io."
     - "10 10 443 b.dnstest.io."
+
+  # Validate a SSHFP record
+  SSHFP:mars.yellowjacket.io:
+    resolvable: true
+    server: 8.8.8.8
+    addrs:
+    - "1 2 422F22EFB548FEAC403A633A86F74553599B85AC93E7EC3BB0A46B6CD6DDABF8"
+    - "3 1 1B28EEA699B1C784DC16F1122EEDDCF3131C89D2"
+    - "3 2 F5982E00758BF5016B9FDDF26D8E495C376E657BAAC4C7DB1B363C06F0D093CC"
+    - "4 1 5802C65FB3F3B62242055A12455C8E9C5B5A3CDA"
+    - "4 2 99DB27696110BB3918599BF35D932D35DAA3DE09D6F42506FDAA08EBD2AD7311"
+    - "1 1 B6B05D527AE206A2A7163AB349166E15D1AFC7E9"
 ```
 
 Please note that if you want `localhost` to **only** resolve `127.0.0.1` you'll need to use [Advanced Matchers](#advanced-matchers)

--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -226,7 +226,7 @@ dns:
     addrs:
     - "dns.google."
 
-  # Validate a SRV record
+  # Validate an SRV record
   SRV:_https._tcp.dnstest.io:
     resolvable: true
     server: 208.67.222.222
@@ -234,7 +234,7 @@ dns:
     - "0 5 443 a.dnstest.io."
     - "10 10 443 b.dnstest.io."
 
-  # Validate a SSHFP record
+  # Validate an SSHFP record
   SSHFP:mars.yellowjacket.io:
     resolvable: true
     server: 8.8.8.8

--- a/system/dns.go
+++ b/system/dns.go
@@ -140,6 +140,8 @@ func DNSlookup(host string, server string, qtype string, timeout int) ([]string,
 				addrs, err = LookupSRV(host, server, c, m)
 			case "TXT":
 				addrs, err = LookupTXT(host, server, c, m)
+			case "SSHFP":
+				addrs, err = LookupSSHFP(host, server, c, m)
 			case "CAA":
 				addrs, err = LookupCAA(host, server, c, m)
 			default:
@@ -283,6 +285,27 @@ func LookupSRV(host string, server string, c *dns.Client, m *dns.Msg) (addrs []s
 			port := strconv.Itoa(int(t.Port))
 			srvrec := strings.Join([]string{prio, weight, port, t.Target}, " ")
 			addrs = append(addrs, srvrec)
+		}
+	}
+
+	return
+}
+
+// SSHFP record lookup
+func LookupSSHFP(host string, server string, c *dns.Client, m *dns.Msg) (addrs []string, err error) {
+	m.SetQuestion(dns.Fqdn(host), dns.TypeSSHFP)
+	r, _, err := c.Exchange(m, parseServerString(server))
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ans := range r.Answer {
+		if t, ok := ans.(*dns.SSHFP); ok {
+			algo := strconv.Itoa(int(t.Algorithm))
+			fpType := strconv.Itoa(int(t.Type))
+			fingerprint := strings.ToUpper(t.FingerPrint)
+			sshfpRec := strings.Join([]string{algo, fpType, fingerprint}, " ")
+			addrs = append(addrs, sshfpRec)
 		}
 	}
 


### PR DESCRIPTION
  * Add SSHFP record lookups.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] documentation is changed or added

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
This commit implements SSHFP (SSH Fingerprint) DNS record type support, allowing you to validate that the ssh host key fingerprints stored in dns match what you expect

<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--1033.org.readthedocs.build/en/1033/

<!-- readthedocs-preview goss end -->