### PR TITLE
Fix #962 - use the title for the jUnit test case name

### DIFF
--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -52,7 +52,7 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult,
         escapeString(testResult.ResourceId),
         testResult.Property);
       if (testResult.Title != "") {
-        testcaseName = testResult.Title;
+        testcaseName = escapeString(testResult.Title);
       }
       summary[testCount] = "<testcase name=\"" +
         testcaseName + "\" " +

--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -54,9 +54,11 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult,
       if (testResult.Title != "") {
         testcaseName = escapeString(testResult.Title);
       }
-      summary[testCount] = "<testcase name=\"" +
-        testcaseName + "\" " +
-        "time=\"" + duration + "\">\n"
+      summary[testCount] = fmt.Sprintf("<testcase name=\"%s\" time=\"%s\">\n",
+        testcaseName,
+        duration,
+      );
+
 			if testResult.Result == resource.FAIL {
 				summary[testCount] += "<system-err>" +
 					escapeString(humanizeResult(testResult, true, includeRaw)) +

--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -47,11 +47,16 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult,
 				endTime = testResult.EndTime
 			}
 			duration := strconv.FormatFloat(testResult.Duration.Seconds(), 'f', 3, 64)
-			summary[testCount] = "<testcase name=\"" +
-				testResult.ResourceType + " " +
-				escapeString(testResult.ResourceId) + " " +
-				testResult.Property + "\" " +
-				"time=\"" + duration + "\">\n"
+      testcaseName := fmt.Sprintf("%s %s %s",
+        testResult.ResourceType,
+        escapeString(testResult.ResourceId),
+        testResult.Property);
+      if (testResult.Title != "") {
+        testcaseName = testResult.Title;
+      }
+      summary[testCount] = "<testcase name=\"" +
+        testcaseName + "\" " +
+        "time=\"" + duration + "\">\n"
 			if testResult.Result == resource.FAIL {
 				summary[testCount] += "<system-err>" +
 					escapeString(humanizeResult(testResult, true, includeRaw)) +

--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -47,14 +47,14 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult,
 				endTime = testResult.EndTime
 			}
 			duration := strconv.FormatFloat(testResult.Duration.Seconds(), 'f', 3, 64)
-			testcaseName := fmt.Sprintf(
-				"%s %s %s",
-				testResult.ResourceType,
-				testResult.ResourceId,
-				testResult.Property,
-			)
-			if (testResult.Title != "") {
-				testcaseName = testResult.Title
+			testcaseName := testResult.Title
+			if testcaseName == "" {
+				testcaseName = fmt.Sprintf(
+					"%s %s %s",
+					testResult.ResourceType,
+					testResult.ResourceId,
+					testResult.Property,
+				)
 			}
 			summary[testCount] = fmt.Sprintf(
 				"<testcase name=\"%s\" time=\"%s\">\n",

--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -49,13 +49,13 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult,
 			duration := strconv.FormatFloat(testResult.Duration.Seconds(), 'f', 3, 64)
       testcaseName := fmt.Sprintf("%s %s %s",
         testResult.ResourceType,
-        escapeString(testResult.ResourceId),
+        testResult.ResourceId,
         testResult.Property);
       if (testResult.Title != "") {
-        testcaseName = escapeString(testResult.Title);
+        testcaseName = testResult.Title
       }
       summary[testCount] = fmt.Sprintf("<testcase name=\"%s\" time=\"%s\">\n",
-        testcaseName,
+        escapeString(testcaseName),
         duration,
       );
 

--- a/outputs/junit.go
+++ b/outputs/junit.go
@@ -47,17 +47,20 @@ func (r JUnit) Output(w io.Writer, results <-chan []resource.TestResult,
 				endTime = testResult.EndTime
 			}
 			duration := strconv.FormatFloat(testResult.Duration.Seconds(), 'f', 3, 64)
-      testcaseName := fmt.Sprintf("%s %s %s",
-        testResult.ResourceType,
-        testResult.ResourceId,
-        testResult.Property);
-      if (testResult.Title != "") {
-        testcaseName = testResult.Title
-      }
-      summary[testCount] = fmt.Sprintf("<testcase name=\"%s\" time=\"%s\">\n",
-        escapeString(testcaseName),
-        duration,
-      );
+			testcaseName := fmt.Sprintf(
+				"%s %s %s",
+				testResult.ResourceType,
+				testResult.ResourceId,
+				testResult.Property,
+			)
+			if (testResult.Title != "") {
+				testcaseName = testResult.Title
+			}
+			summary[testCount] = fmt.Sprintf(
+				"<testcase name=\"%s\" time=\"%s\">\n",
+				escapeString(testcaseName),
+				duration,
+			)
 
 			if testResult.Result == resource.FAIL {
 				summary[testCount] += "<system-err>" +


### PR DESCRIPTION
### Description of change

Fix https://github.com/goss-org/goss/issues/962
This checks for the presence of a "title" attribute on the test-case, and uses that in the jUnit report if it is present.

##### Checklist

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

