### PR TITLE
Fix debug logging regression bug affecting Command tests

### DIFF
--- a/resource/command.go
+++ b/resource/command.go
@@ -49,7 +49,7 @@ func (c *Command) GetExec() string {
 }
 
 func (c *Command) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, c.ID())
+	ctx := context.WithValue(context.Background(), system.CommandIDKey, c.ID())
 	skip := c.Skip
 
 	if c.Timeout == 0 {

--- a/system/command.go
+++ b/system/command.go
@@ -8,8 +8,16 @@ import (
 	"os/exec"
 	"time"
 
+
 	"github.com/goss-org/goss/util"
+	
 )
+
+// CommandIDKeyType is the unique key for command IDs in context.
+type CommandIDKeyType struct{}
+
+// CommandIDKey is the only instance that must be used everywhere.
+var CommandIDKey = CommandIDKeyType{}
 
 type Command interface {
 	Command() string
@@ -54,7 +62,8 @@ func (c *DefCommand) setup() error {
 	c.exitStatus = cmd.Status
 	stdoutB := cmd.Stdout.Bytes()
 	stderrB := cmd.Stderr.Bytes()
-	id := c.Ctx.Value("id")
+
+	id := c.Ctx.Value(CommandIDKey)
 	logBytes(stdoutB, fmt.Sprintf("[Command][%s][stdout] ", id))
 	logBytes(stderrB, fmt.Sprintf("[Command][%s][stderr] ", id))
 	c.stdout = bytes.NewReader(stdoutB)

--- a/system/command.go
+++ b/system/command.go
@@ -10,7 +10,6 @@ import (
 
 
 	"github.com/goss-org/goss/util"
-	
 )
 
 // ContextKey is  for minting unique keys in a context.

--- a/system/command.go
+++ b/system/command.go
@@ -13,11 +13,11 @@ import (
 	
 )
 
-// CommandIDKeyType is the unique key for command IDs in context.
-type CommandIDKeyType struct{}
+// ContextKey is  for minting unique keys in a context.
+type ContextKey struct{}
 
 // CommandIDKey is the only instance that must be used everywhere.
-var CommandIDKey = CommandIDKeyType{}
+var CommandIDKey = ContextKey{}
 
 type Command interface {
 	Command() string

--- a/system/command.go
+++ b/system/command.go
@@ -8,7 +8,6 @@ import (
 	"os/exec"
 	"time"
 
-
 	"github.com/goss-org/goss/util"
 )
 


### PR DESCRIPTION
Fixes a bug introduced by commit 6a8fc96 (according to git bisect + testing ) that broke the logging detail that previously identified the child elements below the Command key.  Examples are visible in #1015

##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

### Description of change

My understanding is that when using strings to identify context, the lookup worked fine. The pull request #922  that included commit 6a8fc96 didn't mention making this change explicitly, only that it included fixes to resolve some linting warnings.  Since the code still compiled I think this bug went unnoticed. 

Open to suggestions/feedback on the method to fix this bug 'correctly' if this implementation isnt the best.

