### PR TITLE
feat(dgoss): allow nerdctl

### DIFF
--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -53,7 +53,7 @@ checks whether the conditions in the file are met. Only then does goss start the
 actual check with the file `./goss.yaml`. This is used, for example, to wait
 until a certain port is open before executing the tests.
 
-In most cases one can just substitute the runtime command (`docker` or `podman`)
+In most cases one can just substitute the runtime command (`docker`, `nerdctl` or `podman`)
 for the dgoss command, for example:
 
 **run:**
@@ -165,5 +165,5 @@ Location of the temporary directory used by dgoss. (Default `'$(mktemp -d /tmp/t
 
 #### CONTAINER_RUNTIME
 
-Container runtime to use - `docker` or `podman`. Defaults to `docker`. Note that `podman` requires a run command to keep
+Container runtime to use - `docker`, `nerdctl` or `podman`. Defaults to `docker`. Note that `podman` requires a run command to keep
 the container running. This defaults to `sleep infinity` in case only an image is passed to `dgoss` commands.

--- a/extras/dgoss/README.md
+++ b/extras/dgoss/README.md
@@ -53,7 +53,7 @@ checks whether the conditions in the file are met. Only then does goss start the
 actual check with the file `./goss.yaml`. This is used, for example, to wait
 until a certain port is open before executing the tests.
 
-In most cases one can just substitute the runtime command (`docker`, `nerdctl` or `podman`)
+In most cases one can just substitute the runtime command (`docker`, `nerdctl`, or `podman`)
 for the dgoss command, for example:
 
 **run:**
@@ -165,5 +165,5 @@ Location of the temporary directory used by dgoss. (Default `'$(mktemp -d /tmp/t
 
 #### CONTAINER_RUNTIME
 
-Container runtime to use - `docker`, `nerdctl` or `podman`. Defaults to `docker`. Note that `podman` requires a run command to keep
+Container runtime to use - `docker`, `nerdctl`, or `podman`. Defaults to `docker`. Note that `podman` requires a run command to keep
 the container running. This defaults to `sleep infinity` in case only an image is passed to `dgoss` commands.

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -102,7 +102,7 @@ GOSS_PATH="${GOSS_PATH:-$(which goss 2> /dev/null || true)}"
 [[ ${GOSS_WAIT_OPTS+x} ]] || GOSS_WAIT_OPTS="-r 30s -s 1s > /dev/null"
 GOSS_SLEEP=${GOSS_SLEEP:-0.2}
 
-[[ $CONTAINER_RUNTIME =~ ^(docker|podman)$ ]] || { error "Runtime must be one of docker or podman"; }
+[[ $CONTAINER_RUNTIME =~ ^(docker|nerdctl|podman)$ ]] || { error "Runtime must be one of docker, nerdctl or podman"; }
 
 case "$1" in
     run)

--- a/extras/dgoss/dgoss
+++ b/extras/dgoss/dgoss
@@ -102,7 +102,7 @@ GOSS_PATH="${GOSS_PATH:-$(which goss 2> /dev/null || true)}"
 [[ ${GOSS_WAIT_OPTS+x} ]] || GOSS_WAIT_OPTS="-r 30s -s 1s > /dev/null"
 GOSS_SLEEP=${GOSS_SLEEP:-0.2}
 
-[[ $CONTAINER_RUNTIME =~ ^(docker|nerdctl|podman)$ ]] || { error "Runtime must be one of docker, nerdctl or podman"; }
+[[ $CONTAINER_RUNTIME =~ ^(docker|nerdctl|podman)$ ]] || { error "Runtime must be one of docker, nerdctl, or podman"; }
 
 case "$1" in
     run)


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->


##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `make test-all` (UNIX) passes. CI will also test this
- [ ] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
In this PR, the script doesn't immediately fail when `CONTAINER_RUNTIME` is [`nerdctl`](https://github.com/containerd/nerdctl).
