### PR TITLE
fix: stop AndMatcher panicking when no child matcher ran (#982)

### DIFF
--- a/matchers/and.go
+++ b/matchers/and.go
@@ -28,7 +28,22 @@ func (m *AndMatcher) Match(actual interface{}) (success bool, err error) {
 	return true, nil
 }
 
+// FailureResult reports the first matcher that failed. firstFailedMatcher is
+// only set once Match has actually run a child matcher, and that does not
+// always happen: WithSafeTransformMatcher.Match returns early when its
+// transform errors — a gjson path that does not exist, for example — so the
+// wrapped And never evaluates anything and its state stays nil. Dereferencing
+// it there panicked (#982). Report the And itself in that case, which keeps the
+// surrounding transform chain and raw value in the output so the user can see
+// which path they actually matched against.
 func (m *AndMatcher) FailureResult(actual interface{}) MatcherResult {
+	if m.firstFailedMatcher == nil {
+		return MatcherResult{
+			Actual:   actual,
+			Message:  "to satisfy all of these matchers",
+			Expected: m.Matchers,
+		}
+	}
 	return m.firstFailedMatcher.FailureResult(actual)
 }
 

--- a/matchers/and.go
+++ b/matchers/and.go
@@ -36,7 +36,7 @@ func (m *AndMatcher) Match(actual interface{}) (success bool, err error) {
 // it there panicked (#982). Report the And itself in that case, which keeps the
 // surrounding transform chain and raw value in the output so the user can see
 // which path they actually matched against.
-func (m *AndMatcher) FailureResult(actual interface{}) MatcherResult {
+func (m *AndMatcher) FailureResult(actual any) MatcherResult {
 	if m.firstFailedMatcher == nil {
 		return MatcherResult{
 			Actual:   actual,

--- a/matchers/and_test.go
+++ b/matchers/and_test.go
@@ -1,0 +1,49 @@
+package matchers
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// erroringTransform fails the way Gjson does when a path is absent.
+type erroringTransform struct{}
+
+func (erroringTransform) Transform(in interface{}) (interface{}, error) {
+	return in, errors.New("Path not found: this.is.typo")
+}
+
+func (erroringTransform) TransformerType() string { return "erroringTransform" }
+
+// A transform that errors makes WithSafeTransformMatcher.Match return before it
+// ever calls the wrapped matcher, so the And never runs a child and its
+// firstFailedMatcher stays nil. Asking it for a FailureResult used to panic
+// (#982).
+func TestAndMatcherFailureResultWhenNoChildMatcherRan(t *testing.T) {
+	inner := And(HaveKey("a"))
+	matcher := WithSafeTransform(erroringTransform{}, inner)
+
+	success, err := matcher.Match(`{"this": {"is": {"just": {"a": "test"}}}}`)
+	assert.False(t, success)
+	assert.Error(t, err)
+
+	assert.NotPanics(t, func() {
+		result := matcher.FailureResult("actual")
+		assert.Equal(t, "to satisfy all of these matchers", result.Message)
+	})
+}
+
+// The nil result must not be returned once a child has genuinely failed —
+// otherwise the guard would swallow the specific matcher that failed.
+func TestAndMatcherFailureResultStillReportsTheFailedChild(t *testing.T) {
+	m := And(HaveKey("missing"))
+
+	success, err := m.Match(map[string]interface{}{"present": 1})
+	assert.False(t, success)
+	assert.NoError(t, err)
+
+	result := m.FailureResult(map[string]interface{}{"present": 1})
+	assert.Equal(t, "to have key matching", result.Message,
+		"must delegate to the child that failed, not the And's own message")
+}

--- a/matchers/and_test.go
+++ b/matchers/and_test.go
@@ -10,7 +10,7 @@ import (
 // erroringTransform fails the way Gjson does when a path is absent.
 type erroringTransform struct{}
 
-func (erroringTransform) Transform(in interface{}) (interface{}, error) {
+func (erroringTransform) Transform(in any) (any, error) {
 	return in, errors.New("Path not found: this.is.typo")
 }
 
@@ -39,11 +39,11 @@ func TestAndMatcherFailureResultWhenNoChildMatcherRan(t *testing.T) {
 func TestAndMatcherFailureResultStillReportsTheFailedChild(t *testing.T) {
 	m := And(HaveKey("missing"))
 
-	success, err := m.Match(map[string]interface{}{"present": 1})
+	success, err := m.Match(map[string]any{"present": 1})
 	assert.False(t, success)
 	assert.NoError(t, err)
 
-	result := m.FailureResult(map[string]interface{}{"present": 1})
+	result := m.FailureResult(map[string]any{"present": 1})
 	assert.Equal(t, "to have key matching", result.Message,
 		"must delegate to the child that failed, not the And's own message")
 }


### PR DESCRIPTION
Closes #982.

## Reproduced on current master

The gossfile from the issue, unchanged, against `master` @ `4a91642`:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20]

matchers.(*AndMatcher).FailureResult          matchers/and.go:32
matchers.(*WithSafeTransformMatcher).FailureResult  matchers/with_safe_transform.go:45
matchers.(*AndMatcher).FailureResult          matchers/and.go:32
resource.ValidateGomegaValue                  resource/validate.go:199
```

Same frames as the 2024 report, 23 months on.

## Cause

`WithSafeTransformMatcher.Match` returns as soon as its transform errors:

```go
m.transformedValue, err = m.Transform.Transform(actual)
...
if err != nil {
    return false, fmt.Errorf("%#v: %w", m.Transform, err)
}
return m.Matcher.Match(m.transformedValue)   // never reached
```

`Gjson.Transform` errors with `Path not found: …` when the path is absent, so the wrapped
`And` never evaluates a child and `firstFailedMatcher` stays `nil`.
`resource/validate.go:199` then branches only on `success`, not on `err`, and calls
`FailureResult` anyway — into the nil.

Your read in the thread was right: it only panics with `and`. I checked — `or`, `not` and a
bare matcher were each run against the same gossfile and none of them panics. `OrMatcher`
survives because its `FailureResult` doesn't touch `firstSuccessfulMatcher` at all.

## Fix

A nil guard in `AndMatcher.FailureResult`, reporting the `And` itself when no child ran.

**I chose this over the other obvious fix, and the output is why.** The alternative is to make
`validate.go` skip `FailureResult` when `Match` returned an error — arguably more correct,
since a matcher that errored has undefined state, and it would mirror the existing early
return a few lines above. I implemented both and compared what the user actually sees:

*validate.go variant:*
```
Matching: example: matches:
Error
    matchers.Gjson{Path:"this.is.typo"}: Path not found: this.is.typo
```

*this PR:*
```
Matching: example: matches:
Error
    matchers.Gjson{Path:"this.is.typo"}: Path not found: this.is.typo
the transform chain was
    [{"gjson":{"Path":"this.is.typo"}}]
the raw value was
    "{\"this\": {\"is\": {\"just\": {\"a\": \"test\"}}}}"
```

Keeping `FailureResult` in the chain preserves the transform chain and the raw value — which
is exactly what makes a typo'd gjson path obvious, since you can see the document you were
matching against. Happy to switch to the `validate.go` version if you'd rather have the
stricter semantics; it's a two-line change and I have it ready.

## Tests

Two, both in `matchers/and_test.go`:

- the panic case — an erroring transform wrapping an `And`, asserting `FailureResult` doesn't
  panic and reports the And;
- the delegation case — an `And` whose child genuinely failed must still report *that child*,
  not the And's own message. Without this, a guard that always fired would look correct.

**Mutation-tested:** removing the guard fails the first test with the original panic; making
the guard always fire fails the second. Each test fails for its own reason and nothing else
moves.

`go test -race ./...` passes, `gofmt -l` clean, `go vet` clean, and `golangci-lint run` (v2.12.2,
the full `$(pkgs)` list) reports **0 issues** on this branch.

*Edited: this originally said I didn't have `golangci-lint` locally. @kgaughan pointed out that
`make lint` installs it — he was right, and the real reason I didn't have a result is in
[the comment below](https://github.com/goss-org/goss/pull/1099#issuecomment-5225391505).*

