### PR TITLE
feat(kgoss): add GOSS_KUBECTL_TIMEOUT to allow slow pod startups

### DIFF
--- a/extras/kgoss/README.md
+++ b/extras/kgoss/README.md
@@ -116,6 +116,7 @@ The following environment variables effect the behavior of kgoss.
 | GOSS\_FILES\_PATH | Location of the goss yaml files | `.` |
 | GOSS\_KUBECTL\_BIN | Kubenetes client tool to use | `$(which kubectl)` |
 | GOSS\_KUBECTL\_OPTS | Options to inject more options such as "--namespace=default" | "" |
+| GOSS\_KUBECTL\_TIMEOUT | Kubectl wait timout for the tester pod to reach ready condition | "60s" |
 | GOSS\_KUBECTL\_RUN\_OPTS | Options only for kubectl run (e.g. --overrides for serviceAccount) | "" |
 | GOSS\_OPTS | Options to use for the goss test run. | `--color --format documentation` |
 | GOSS\_WAIT\_OPTS | Options to use for the goss wait run, when `./goss_wait.yaml` exists. | `-r 30s -s 1s > /dev/null` |

--- a/extras/kgoss/kgoss
+++ b/extras/kgoss/kgoss
@@ -40,6 +40,7 @@ If -p, -c and -a are not specified, container will run its ENTRYPOINT.
 
 GOSS_KUBECTL_BIN="$(which kubectl)": location of kubectl-compatible binary
 GOSS_KUBECTL_OPTS="": hook to inject more options such as "--namespace=default"
+GOSS_KUBECTL_TIMEOUT="60s": kubectl wait timout for the tester pod to reach ready condition
 GOSS_KUBECTL_RUN_OPTS="": options only for kubectl run (e.g. --overrides for serviceAccount)
 GOSS_PATH="$(which goss)": location of goss binary
 GOSS_FILES_PATH=".": location of goss.yaml and other configuration files
@@ -58,7 +59,7 @@ if [[ -z "${GOSS_PATH}" ]]; then
         GOSS_PATH=$(which goss 2> /dev/null)
     elif [[ -e "${HOME}/goss" ]]; then
         GOSS_PATH="${HOME}/goss"
-    elif [[ -e "${HOME}/bin/goss" ]]; then 
+    elif [[ -e "${HOME}/bin/goss" ]]; then
         GOSS_PATH="${HOME}/bin/goss"
     else
         error "Couldn't find goss, please set GOSS_PATH to it"
@@ -75,6 +76,7 @@ GOSS_OPTS=${GOSS_OPTS:-"--color --format documentation"}
 GOSS_WAIT_OPTS=${GOSS_WAIT_OPTS:-"-r 30s -s 1s > /dev/null"}
 GOSS_CONTAINER_PATH=${GOSS_CONTAINER_PATH:-/tmp/goss}
 GOSS_KUBECTL_OPTS=${GOSS_KUBECTL_OPTS:-""}
+GOSS_KUBECTL_TIMEOUT=${GOSS_KUBECTL_TIMEOUT:-"60s"}
 # GOSS_KUBECTL_RUN_OPTS: additional options only for kubectl run (e.g. --overrides for serviceAccount, nodeSelector)
 GOSS_KUBECTL_RUN_OPTS=${GOSS_KUBECTL_RUN_OPTS:-""}
 
@@ -208,7 +210,7 @@ initialize () {
           --image=${image} ${to_exec} )
         set +x
         info "Waiting for container to be ready"
-        ${k} wait pod/${test_pod_name} --for=condition=Ready --timeout=60s  ${GOSS_KUBECTL_OPTS}
+        ${k} wait pod/${test_pod_name} --for=condition=Ready --timeout=${GOSS_KUBECTL_TIMEOUT} ${GOSS_KUBECTL_OPTS}
         info "Copying goss files into pod/container"
         ${k} cp ${GOSS_KUBECTL_OPTS} $tmp_dir/. ${id}:${GOSS_CONTAINER_PATH}/
         info "Marking copied files as executable"


### PR DESCRIPTION
##### Checklist
- [x] documentation is changed or added 

### Description of change
When running many builds in parallel on a small machine, pod starts can be too slow. Currently the timeout had a fixed value of 60s. I moved the setting to a new env var GOSS_KUBECTL_TIMEOUT with the same default, to make it configurable. 

<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--1106.org.readthedocs.build/en/1106/

<!-- readthedocs-preview goss end -->