### PR TITLE
fix(prometheus): return a failure exit code, and seed the run outcome once

### DIFF
--- a/outputs/prometheus.go
+++ b/outputs/prometheus.go
@@ -46,9 +46,10 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 	}
 
 	overallOutcome := resource.OutcomeUnknown
+	first := true
 	var startTime time.Time
 	for resultGroup := range results {
-		for i, tr := range resultGroup {
+		for _, tr := range resultGroup {
 			if startTime.IsZero() || tr.StartTime.Before(startTime) {
 				startTime = tr.StartTime
 			}
@@ -62,8 +63,11 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 				testOutcomes.WithLabelValues(resType, outcome).Inc()
 				testDurations.WithLabelValues(resType, outcome).Add(float64(tr.Duration.Milliseconds()))
 			}
-			if i == 0 || canChangeOverallOutcome(overallOutcome, outcome) {
+			// seed once across all groups, not once per group: results arrive
+			// in several groups in a nondeterministic order
+			if first || canChangeOverallOutcome(overallOutcome, outcome) {
 				overallOutcome = outcome
+				first = false
 			}
 		}
 	}
@@ -84,6 +88,9 @@ func (r Prometheus) Output(w io.Writer, results <-chan []resource.TestResult,
 		}
 	}
 
+	if overallOutcome == resource.OutcomeFail {
+		return 1
+	}
 	return 0
 }
 

--- a/outputs/prometheus_test.go
+++ b/outputs/prometheus_test.go
@@ -14,9 +14,10 @@ import (
 
 func TestPrometheusOutput(t *testing.T) {
 	testCases := map[string]struct {
-		results         []resource.TestResult
-		formatOptions   []string
-		expectedMetrics []string
+		results          []resource.TestResult
+		formatOptions    []string
+		expectedMetrics  []string
+		expectedExitCode int
 	}{
 		"all-success-single-type": {
 			results: []resource.TestResult{
@@ -77,6 +78,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"all-unknown-single-type": {
 			results: []resource.TestResult{
@@ -155,6 +157,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"various-results-multiple-types": {
 			results: []resource.TestResult{
@@ -191,6 +194,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"unknown-skip": {
 			results: []resource.TestResult{
@@ -235,6 +239,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"unknown-success": {
 			results: []resource.TestResult{
@@ -301,6 +306,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"skip-success": {
 			results: []resource.TestResult{
@@ -345,6 +351,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"fail-skip": {
 			results: []resource.TestResult{
@@ -367,6 +374,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"fail-success": {
 			results: []resource.TestResult{
@@ -389,6 +397,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"success-unknown": {
 			results: []resource.TestResult{
@@ -455,6 +464,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 		"no-results": {
 			results: []resource.TestResult{},
@@ -495,6 +505,7 @@ func TestPrometheusOutput(t *testing.T) {
 				`goss_tests_run_duration_milliseconds{outcome="fail"}`,
 				`goss_tests_run_outcomes_total{outcome="fail"} 1`,
 			},
+			expectedExitCode: 1,
 		},
 	}
 
@@ -509,7 +520,7 @@ func TestPrometheusOutput(t *testing.T) {
 			defer resetMetrics()
 
 			exitCode := outputer.Output(buf, makeResults(testCase.results...), config)
-			assert.Equal(t, 0, exitCode)
+			assert.Equal(t, testCase.expectedExitCode, exitCode)
 
 			output := buf.String()
 			t.Log(output)


### PR DESCRIPTION
`Prometheus.Output` always returned 0, so `serve -f prometheus` never answered 503 on `/healthz` and `validate -f prometheus` never failed a pipeline:

```
documentation  exit=1
json           exit=1
prometheus     exit=0    <- failing spec
```

This is what @petemounce proposed in #992: L87 should return 1 when there are failure outcomes.

Closes #992

## The second half

Fixing only the exit code would have made the 503 fire at random.

The seed check was `i == 0 || canChangeOverallOutcome(...)`, where `i` is the index **within a result group**. goss delivers results as several groups in a nondeterministic order, so any group whose first entry passed reset a previously recorded failure. Same spec, six consecutive runs, before this change:

```
goss_tests_run_outcomes_total{outcome="fail"} 1
goss_tests_run_outcomes_total{outcome="pass"} 1
goss_tests_run_outcomes_total{outcome="pass"} 1
goss_tests_run_outcomes_total{outcome="fail"} 1
goss_tests_run_outcomes_total{outcome="fail"} 1
goss_tests_run_outcomes_total{outcome="fail"} 1
```

So the reported run outcome was already wrong roughly a third of the time, independently of the exit code. Seeding once across all groups rather than once per group fixes it — six runs after the change are all `fail`, and an all-passing spec still reports `pass` with exit 0.

I kept `canChangeOverallOutcome` unchanged. Dropping the seed entirely and relying on its `unknown` branch looks tempting but is wrong: `unknown` is also a real test result, and `unknown-success` must stay `unknown` rather than being promoted to `pass`.

## Behaviour change worth noting in release notes

`validate -f prometheus` now exits 1 on failure where it exited 0 before. That is the point of the issue, but it is user-visible for anyone using that format in CI.

`/metrics` is unaffected — it is served by a separate `promhttp.Handler()` on the default registry and shares nothing with this outputer's private registry. The 503 also still writes the full metrics body, since `serve.go` writes the body unconditionally.

## Tests

`go test ./...` passes across all six packages.

`TestPrometheusOutput` hardcoded `assert.Equal(t, 0, exitCode)` for every case, which is exactly what caught this change. The struct now carries `expectedExitCode`, set to 1 on the 10 cases whose expected run outcome is `fail`, and left 0 elsewhere.
