### PR TITLE
fix(serve): dedupe concurrent validation runs on a cold cache

### DIFF
--- a/serve.go
+++ b/serve.go
@@ -104,23 +104,20 @@ func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outputer outputs.Outputer) res {
 	var tra [][]resource.TestResult
 	cacheKey := "res"
-	tmp, found := h.cache.Get(cacheKey)
-	if found {
+	// Held across the lookup so a miss does not let a second request start its
+	// own validate() before the first one has filled the cache.
+	h.gossMu.Lock()
+	if tmp, found := h.cache.Get(cacheKey); found {
 		log.Printf("[TRACE] Returning cached[%s].", cacheKey)
 		tra = tmp.([][]resource.TestResult)
 	} else {
-		h.gossMu.Lock()
-		// another request may have filled the cache while we waited for the lock
-		if tmp, found := h.cache.Get(cacheKey); found {
-			tra = tmp.([][]resource.TestResult)
-		} else {
-			log.Printf(cacheMissLogFormat, cacheKey)
-			h.sys = system.New(h.c.PackageManager)
-			tra = h.validate()
-			h.cache.SetDefault(cacheKey, tra)
-		}
-		h.gossMu.Unlock()
+		log.Printf(cacheMissLogFormat, cacheKey)
+		h.sys = system.New(h.c.PackageManager)
+		tra = h.validate()
+		h.cache.SetDefault(cacheKey, tra)
 	}
+	h.gossMu.Unlock()
+
 	trc := testResultArrayToChan(tra)
 	return h.output(trc, outputer)
 }

--- a/serve.go
+++ b/serve.go
@@ -109,10 +109,17 @@ func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outp
 		log.Printf("[TRACE] Returning cached[%s].", cacheKey)
 		tra = tmp.([][]resource.TestResult)
 	} else {
-		log.Printf(cacheMissLogFormat, cacheKey)
-		h.sys = system.New(h.c.PackageManager)
-		tra = h.validate()
-		h.cache.SetDefault(cacheKey, tra)
+		h.gossMu.Lock()
+		// another request may have filled the cache while we waited for the lock
+		if tmp, found := h.cache.Get(cacheKey); found {
+			tra = tmp.([][]resource.TestResult)
+		} else {
+			log.Printf(cacheMissLogFormat, cacheKey)
+			h.sys = system.New(h.c.PackageManager)
+			tra = h.validate()
+			h.cache.SetDefault(cacheKey, tra)
+		}
+		h.gossMu.Unlock()
 	}
 	trc := testResultArrayToChan(tra)
 	return h.output(trc, outputer)

--- a/serve_concurrency_test.go
+++ b/serve_concurrency_test.go
@@ -1,9 +1,12 @@
 package goss
 
 import (
+	"log"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
@@ -44,4 +47,37 @@ func TestServeHandlesConcurrentRequests(t *testing.T) {
 		}()
 	}
 	wg.Wait()
+}
+
+// TestServeDeduplicatesConcurrentCacheMisses covers the cold window: when many
+// probes arrive before any result is cached, they must share one validation
+// run rather than each executing every check against the machine.
+func TestServeDeduplicatesConcurrentCacheMisses(t *testing.T) {
+	var logOutput syncBuffer
+	log.SetOutput(&logOutput)
+	t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+	config, err := util.NewConfig(
+		util.WithSpecFile(filepath.Join("testdata", "matching_basic.yaml")),
+		util.WithOutputFormat("json"),
+	)
+	require.NoError(t, err)
+
+	handler, err := newHealthHandler(config)
+	require.NoError(t, err)
+
+	const n = 16
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for range n {
+		go func() {
+			defer wg.Done()
+			rr := httptest.NewRecorder()
+			handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+		}()
+	}
+	wg.Wait()
+
+	runs := strings.Count(logOutput.String(), "running tests")
+	require.Equal(t, 1, runs, "%d concurrent requests caused %d validation runs, want 1", n, runs)
 }


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this (the Makefile has no `test-all` target; ran `make test-short-all`, which is `fmt lint vet test`, all green, plus `golangci-lint run` explicitly since the make step could not find the binary on PATH: `0 issues.`)
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable) (no docs change needed, this fixes internal serialisation and does not alter documented behaviour)

### Description of change

Fixes #1094.

## What's broken

When the result cache is cold, every concurrent request runs its own full validation. With the reporter's test on master:

```
16 concurrent requests produced 10 validation runs
```

For a gossfile with `command` resources, that means every command executes ten times against the machine for one cold window. The reporter saw 16 of 16 on darwin, so the multiplier is timing dependent, but the shape is the same.

## The cause

The cache-miss branch of `processAndEnsureCached` in `serve.go` has no serialisation. N requests arriving before the first result is stored each build their own `system.New` and run every check.

The telling detail: `gossMu` is already on the handler, constructed at `serve.go:63` and declared at `:79`. `grep` finds zero `.Lock()` calls on it anywhere in the repo. The intent was there, the lock was never taken.

## The fix

Lock around the miss branch and re-check the cache inside the lock. The second `Get` is what turns serialisation into deduplication: without it the waiters would queue up and each still run.

No new dependency, and it uses the field that was already there.

## The trade-off, stated plainly

Waiters now block on the leader instead of each starting their own run, so during a cold window p99 latency becomes one validation duration rather than N concurrent ones. That is the intended exchange and it is strictly less load on the machine, but it is a behaviour change worth naming.

## Verification

```
before:  16 concurrent requests caused 3 validation runs
after:   16 concurrent requests caused 1 validation run
```

The new test lives beside `TestServeHandlesConcurrentRequests` and counts the cache-miss log line, reusing the `syncBuffer` helper the serve tests already use for this. Reverting the source with the test kept makes it fail with the line above.

`go build ./...`, `go vet ./...`, `gofmt -l .` and `go test -race -count=1 ./...` are all clean. The existing `TestServeHandlesConcurrentRequests` still passes unchanged; it was passing with the stampede present, so it needed checking rather than amending.

## One note on ownership

@dukelion offered in the issue to open a PR for this and said "Happy to open a PR if the approach sounds reasonable". That was twelve days ago with no reply. If he would rather take it, I am happy to close this in favour of his.

*Disclosure: written with AI assistance (Claude Code). I reproduced the issue, ran the change and the verification myself.*