### PR TITLE
fix(add): stop the file generator emitting an empty contents list

### DIFF
--- a/integration-tests/goss/alpine3/goss-expected-q.yaml
+++ b/integration-tests/goss/alpine3/goss-expected-q.yaml
@@ -1,10 +1,8 @@
 file:
   /etc/passwd:
     exists: true
-    contents: []
   /tmp/goss/foobar:
     exists: false
-    contents: []
 package:
   apache2:
     installed: true

--- a/integration-tests/goss/alpine3/goss-expected.yaml
+++ b/integration-tests/goss/alpine3/goss-expected.yaml
@@ -5,10 +5,8 @@ file:
     owner: root
     group: root
     filetype: file
-    contents: []
   /tmp/goss/foobar:
     exists: false
-    contents: []
 package:
   apache2:
     installed: true

--- a/integration-tests/goss/bullseye/goss-expected-q.yaml
+++ b/integration-tests/goss/bullseye/goss-expected-q.yaml
@@ -1,10 +1,8 @@
 file:
   /etc/passwd:
     exists: true
-    contents: []
   /tmp/goss/foobar:
     exists: false
-    contents: []
 package:
   apache2:
     installed: true

--- a/integration-tests/goss/bullseye/goss-expected.yaml
+++ b/integration-tests/goss/bullseye/goss-expected.yaml
@@ -5,10 +5,8 @@ file:
     owner: root
     group: root
     filetype: file
-    contents: []
   /tmp/goss/foobar:
     exists: false
-    contents: []
 package:
   apache2:
     installed: true

--- a/integration-tests/goss/jammy/goss-expected-q.yaml
+++ b/integration-tests/goss/jammy/goss-expected-q.yaml
@@ -1,10 +1,8 @@
 file:
   /etc/passwd:
     exists: true
-    contents: []
   /tmp/goss/foobar:
     exists: false
-    contents: []
 package:
   apache2:
     installed: true

--- a/integration-tests/goss/jammy/goss-expected.yaml
+++ b/integration-tests/goss/jammy/goss-expected.yaml
@@ -5,10 +5,8 @@ file:
     owner: root
     group: root
     filetype: file
-    contents: []
   /tmp/goss/foobar:
     exists: false
-    contents: []
 package:
   apache2:
     installed: true

--- a/integration-tests/goss/rockylinux9/goss-expected-q.yaml
+++ b/integration-tests/goss/rockylinux9/goss-expected-q.yaml
@@ -1,10 +1,8 @@
 file:
   /etc/passwd:
     exists: true
-    contents: []
   /tmp/goss/foobar:
     exists: false
-    contents: []
 package:
   foobar:
     installed: false

--- a/integration-tests/goss/rockylinux9/goss-expected.yaml
+++ b/integration-tests/goss/rockylinux9/goss-expected.yaml
@@ -5,10 +5,8 @@ file:
     owner: root
     group: root
     filetype: file
-    contents: []
   /tmp/goss/foobar:
     exists: false
-    contents: []
 package:
   foobar:
     installed: false

--- a/resource/file.go
+++ b/resource/file.go
@@ -24,7 +24,7 @@ type File struct {
 	LinkedTo matcher `json:"linked-to,omitempty" yaml:"linked-to,omitempty"`
 	Filetype matcher `json:"filetype,omitempty" yaml:"filetype,omitempty"`
 	Contains matcher `json:"contains,omitempty" yaml:"contains,omitempty"`
-	Contents matcher `json:"contents" yaml:"contents"`
+	Contents matcher `json:"contents,omitempty" yaml:"contents,omitempty"`
 	Md5      matcher `json:"md5,omitempty" yaml:"md5,omitempty"`
 	Sha256   matcher `json:"sha256,omitempty" yaml:"sha256,omitempty"`
 	Sha512   matcher `json:"sha512,omitempty" yaml:"sha512,omitempty"`
@@ -120,9 +120,8 @@ func NewFile(sysFile system.File, config util.Config) (*File, error) {
 		return nil, err
 	}
 	f := &File{
-		id:       path,
-		Exists:   exists,
-		Contents: []string{},
+		id:     path,
+		Exists: exists,
 	}
 	if !contains(config.IgnoreList, "mode") {
 		if mode, err := sysFile.Mode(); err == nil {

--- a/resource/file_test.go
+++ b/resource/file_test.go
@@ -1,0 +1,33 @@
+package resource
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/goss-org/goss/system"
+	"github.com/goss-org/goss/util"
+
+	"gopkg.in/yaml.v3"
+)
+
+// NewFile used to set Contents to an empty list, so every generated gossfile
+// warned about asserting nothing. It must stay unset and marshal away.
+func TestNewFileLeavesContentsUnset(t *testing.T) {
+	sysFile := system.NewDefFile(context.Background(), "/etc/hostname", nil, util.Config{})
+	f, err := NewFile(sysFile, util.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if f.Contents != nil {
+		t.Errorf("NewFile Contents = %#v, want nil", f.Contents)
+	}
+
+	out, err := yaml.Marshal(f)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(out), "contents") {
+		t.Errorf("marshalled file contains a contents key:\n%s", out)
+	}
+}


### PR DESCRIPTION
Follow-up to #1095, which you said could be fixed separately.

## What's broken

`goss add file` writes `contents: []`, so goss warns about its own generated output:

```
$ goss -g /tmp/g1.yaml add file /etc/hostname
$ goss -g /tmp/g1.yaml validate
WARNING: /etc/hostname: file.contents is an empty list, which asserts nothing and always passes. Use "" to assert empty content, or remove it.
.....
Count: 5, Failed: 0, Skipped: 0
```

The warning is accurate, that line really does assert nothing, which is why the generator should not be writing it.

## The cause

`NewFile` in `resource/file.go` sets `Contents: []string{}` unconditionally, and the `Contents` tag was the only matcher field on `File` without `omitempty`. Every sibling on the surrounding lines has it.

## The fix

Add `omitempty` and drop the constructor's empty slice. After:

```
file:
    /etc/hostname:
        exists: true
        mode: "0644"
        owner: root
        group: root
        filetype: file

Count: 5, Failed: 0, Skipped: 0
```

No warning, and the check count is unchanged.

## Fixtures

16 `contents: []` lines removed across the 8 generated `goss-expected*.yaml` files.

I left the 17th, `integration-tests/goss/goss-shared.yaml:40`, alone. That one is hand-written validate input rather than generator output, and `omitempty` only affects serialisation, so it still parses exactly as before.

I could not run the integration suite here, it needs Docker. Instead I verified each of the 8 edited fixtures by running the real generator for `/etc/passwd` and a nonexistent path, in both default and `--exclude-attr '*'` modes, and diffing its output against each file's `file:` block. 8 of 8 matched. Worth a second look from someone who can run the suite.

## One thing worth naming

`omitempty` also drops a user's hand-written `contents: []` when it round-trips through `goss add`. That is the intended effect, since the line asserted nothing, but it is a serialisation change rather than purely a generator change.

## Same pattern elsewhere, not fixed here

`resource/http.go` has it too: `NewHTTP` sets `Body: []string{}` and its tag already has `omitempty`, so there the fix is just dropping the constructor init. Confirmed live, `goss add http https://example.com` emits `body: []` and validate warns. I kept it out to keep this to one concern, happy to send it separately.

`command.go` initialises `Stdout` and `Stderr` to `""` rather than a slice, so it does not warn, though those tags also lack `omitempty`.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .`, `./ci/go-fmt.sh` and `go test ./...` all clean.

A unit test asserts `NewFile` leaves `Contents` nil and that the marshalled YAML has no `contents` key. Reverting `resource/file.go` with the test kept fails it.
