### PR TITLE
fix(add): stop the http generator emitting an empty body list

### DIFF
--- a/integration-tests/goss/alpine3/goss-expected-q.yaml
+++ b/integration-tests/goss/alpine3/goss-expected-q.yaml
@@ -111,17 +111,14 @@ http:
     allow-insecure: false
     no-follow-redirects: true
     timeout: 5000
-    body: []
   https://www.apple.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []
     proxy: http://127.0.0.1:8888
   https://www.google.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []

--- a/integration-tests/goss/alpine3/goss-expected.yaml
+++ b/integration-tests/goss/alpine3/goss-expected.yaml
@@ -155,17 +155,14 @@ http:
     allow-insecure: false
     no-follow-redirects: true
     timeout: 5000
-    body: []
   https://www.apple.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []
     proxy: http://127.0.0.1:8888
   https://www.google.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []

--- a/integration-tests/goss/bullseye/goss-expected-q.yaml
+++ b/integration-tests/goss/bullseye/goss-expected-q.yaml
@@ -111,17 +111,14 @@ http:
     allow-insecure: false
     no-follow-redirects: true
     timeout: 5000
-    body: []
   https://www.apple.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []
     proxy: http://127.0.0.1:8888
   https://www.google.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []

--- a/integration-tests/goss/bullseye/goss-expected.yaml
+++ b/integration-tests/goss/bullseye/goss-expected.yaml
@@ -161,17 +161,14 @@ http:
     allow-insecure: false
     no-follow-redirects: true
     timeout: 5000
-    body: []
   https://www.apple.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []
     proxy: http://127.0.0.1:8888
   https://www.google.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []

--- a/integration-tests/goss/jammy/goss-expected-q.yaml
+++ b/integration-tests/goss/jammy/goss-expected-q.yaml
@@ -111,17 +111,14 @@ http:
     allow-insecure: false
     no-follow-redirects: true
     timeout: 5000
-    body: []
   https://www.apple.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []
     proxy: http://127.0.0.1:8888
   https://www.google.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []

--- a/integration-tests/goss/jammy/goss-expected.yaml
+++ b/integration-tests/goss/jammy/goss-expected.yaml
@@ -161,17 +161,14 @@ http:
     allow-insecure: false
     no-follow-redirects: true
     timeout: 5000
-    body: []
   https://www.apple.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []
     proxy: http://127.0.0.1:8888
   https://www.google.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []

--- a/integration-tests/goss/rockylinux9/goss-expected-q.yaml
+++ b/integration-tests/goss/rockylinux9/goss-expected-q.yaml
@@ -111,17 +111,14 @@ http:
     allow-insecure: false
     no-follow-redirects: true
     timeout: 5000
-    body: []
   https://www.apple.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []
     proxy: http://127.0.0.1:8888
   https://www.google.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []

--- a/integration-tests/goss/rockylinux9/goss-expected.yaml
+++ b/integration-tests/goss/rockylinux9/goss-expected.yaml
@@ -161,17 +161,14 @@ http:
     allow-insecure: false
     no-follow-redirects: true
     timeout: 5000
-    body: []
   https://www.apple.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []
     proxy: http://127.0.0.1:8888
   https://www.google.com:
     status: 200
     allow-insecure: false
     no-follow-redirects: false
     timeout: 5000
-    body: []

--- a/resource/http.go
+++ b/resource/http.go
@@ -103,7 +103,6 @@ func NewHTTP(sysHTTP system.HTTP, config util.Config) (*HTTP, error) {
 		Status:            status,
 		RequestHeader:     []string{},
 		Headers:           nil,
-		Body:              []string{},
 		AllowInsecure:     config.AllowInsecure,
 		NoFollowRedirects: config.NoFollowRedirects,
 		Timeout:           config.TimeOutMilliSeconds(),

--- a/resource/http_test.go
+++ b/resource/http_test.go
@@ -1,0 +1,46 @@
+package resource
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/goss-org/goss/util"
+	"gopkg.in/yaml.v3"
+)
+
+// fakeSysHTTP is a minimal system.HTTP implementation used to drive NewHTTP
+// in tests without making a real network call.
+type fakeSysHTTP struct{}
+
+func (f *fakeSysHTTP) HTTP() string                { return "https://example.com" }
+func (f *fakeSysHTTP) Status() (int, error)        { return 200, nil }
+func (f *fakeSysHTTP) Headers() (io.Reader, error) { return nil, nil }
+func (f *fakeSysHTTP) Body() (io.Reader, error)    { return nil, nil }
+func (f *fakeSysHTTP) Exists() (bool, error)       { return true, nil }
+func (f *fakeSysHTTP) SetAllowInsecure(bool)       {}
+func (f *fakeSysHTTP) SetNoFollowRedirects(bool)   {}
+func (f *fakeSysHTTP) Close() error                { return nil }
+
+// TestNewHTTPLeavesBodyUnset pins the fix for `goss add http` writing
+// `body: []` into generated gossfiles: an empty list is falsy for
+// isSetWarnEmpty/ValidateValue, so goss validate would warn on goss's own
+// generated output. NewHTTP must leave Body nil (matching the field's
+// yaml:"body,omitempty" tag) rather than initializing it to []string{}.
+func TestNewHTTPLeavesBodyUnset(t *testing.T) {
+	h, err := NewHTTP(&fakeSysHTTP{}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewHTTP returned error: %v", err)
+	}
+	if h.Body != nil {
+		t.Errorf("NewHTTP().Body = %#v, want nil", h.Body)
+	}
+
+	out, err := yaml.Marshal(h)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(out), "body:") {
+		t.Errorf("marshalled yaml contains a body key, want it omitted:\n%s", out)
+	}
+}


### PR DESCRIPTION
## What's broken

`goss add http` writes `body: []` into the generated gossfile, and `goss validate` then warns about goss's own output.

## Repro

```
$ goss add http https://example.com --gossfile goss2.yaml && goss validate
WARNING: https://example.com: http.body is an empty list, which asserts nothing and always passes...
```

## The fix

`NewHTTP()` initialised `Body: []string{}`. The yaml tag already has `omitempty`, so leaving it nil omits the key and the warning goes away. Same shape as #1111, which does this for the file resource, but a different file and no overlap with it.

Reading is unaffected: an existing gossfile that already has `body: []` renders and validates exactly as before. The only call sites are `isSetWarnEmpty` and `ValidateValue`, both nil-safe.

The generated fixtures under `integration-tests/goss/*/goss-expected*.yaml` are updated to match, since `test.sh` diffs fresh `goss add` output against them. `docs/rendered_goss.yaml` and `goss-shared.yaml` keep their `body: []`, they are hand-written inputs rather than generated output.

## Verification

Added `resource/http_test.go` asserting a fresh HTTP resource leaves Body nil and that marshalling omits the key. It fails with `Body: []string{}` restored. `go test ./...` passes, and the updated fixtures match real `goss add http` output run locally.
