### PR TITLE
fix(add): stop four more generators emitting empty lists

### DIFF
--- a/integration-tests/goss/alpine3/goss-expected.yaml
+++ b/integration-tests/goss/alpine3/goss-expected.yaml
@@ -33,10 +33,8 @@ port:
     - 0.0.0.0
   tcp:9999:
     listening: false
-    ip: []
   tcp6:80:
     listening: false
-    ip: []
 service:
   apache2:
     enabled: true

--- a/integration-tests/goss/bullseye/goss-expected.yaml
+++ b/integration-tests/goss/bullseye/goss-expected.yaml
@@ -33,10 +33,8 @@ port:
     - 0.0.0.0
   tcp:9999:
     listening: false
-    ip: []
   tcp6:80:
     listening: false
-    ip: []
 service:
   apache2:
     enabled: true

--- a/integration-tests/goss/jammy/goss-expected.yaml
+++ b/integration-tests/goss/jammy/goss-expected.yaml
@@ -33,10 +33,8 @@ port:
     - 0.0.0.0
   tcp:9999:
     listening: false
-    ip: []
   tcp6:80:
     listening: false
-    ip: []
 service:
   apache2:
     enabled: true

--- a/integration-tests/goss/rockylinux9/goss-expected.yaml
+++ b/integration-tests/goss/rockylinux9/goss-expected.yaml
@@ -33,10 +33,8 @@ port:
     - 0.0.0.0
   tcp:9999:
     listening: false
-    ip: []
   tcp6:80:
     listening: false
-    ip: []
 service:
   foobar:
     enabled: false

--- a/resource/dns.go
+++ b/resource/dns.go
@@ -93,8 +93,11 @@ func NewDNS(sysDNS system.DNS, config util.Config) (*DNS, error) {
 		Server:     server,
 	}
 	if !contains(config.IgnoreList, "addrs") {
-		addrs, _ := sysDNS.Addrs()
-		d.Addrs = addrs
+		// An empty list asserts nothing, so leave Addrs unset and let omitempty
+		// drop it rather than generating `addrs: []`.
+		if addrs, _ := sysDNS.Addrs(); len(addrs) > 0 {
+			d.Addrs = addrs
+		}
 	}
 	return d, err
 }

--- a/resource/dns_test.go
+++ b/resource/dns_test.go
@@ -1,0 +1,60 @@
+package resource
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goss-org/goss/util"
+	"gopkg.in/yaml.v3"
+)
+
+// fakeSysDNS is a minimal system.DNS implementation used to drive NewDNS
+// without doing a real lookup.
+type fakeSysDNS struct {
+	addrs []string
+}
+
+func (f *fakeSysDNS) Host() string              { return "no-such-host-xyz.invalid" }
+func (f *fakeSysDNS) Addrs() ([]string, error)  { return f.addrs, nil }
+func (f *fakeSysDNS) Resolvable() (bool, error) { return false, nil }
+func (f *fakeSysDNS) Exists() (bool, error)     { return false, nil }
+func (f *fakeSysDNS) Server() string            { return "" }
+func (f *fakeSysDNS) Qtype() string             { return "" }
+
+// TestNewDNSLeavesAddrsUnsetWhenEmpty pins the fix for `goss add dns` writing
+// `addrs: []` into generated gossfiles for an unresolvable host. An empty list
+// asserts nothing, so NewDNS must leave Addrs nil (matching the field's
+// yaml:"addrs,omitempty" tag) rather than assigning the empty slice.
+func TestNewDNSLeavesAddrsUnsetWhenEmpty(t *testing.T) {
+	d, err := NewDNS(&fakeSysDNS{addrs: nil}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewDNS returned error: %v", err)
+	}
+	if d.Addrs != nil {
+		t.Errorf("NewDNS().Addrs = %#v, want nil", d.Addrs)
+	}
+
+	out, err := yaml.Marshal(d)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(out), "addrs:") {
+		t.Errorf("marshalled yaml contains an addrs key, want it omitted:\n%s", out)
+	}
+}
+
+// TestNewDNSKeepsAddrsWhenPresent makes sure the empty-list guard does not drop
+// real values.
+func TestNewDNSKeepsAddrsWhenPresent(t *testing.T) {
+	d, err := NewDNS(&fakeSysDNS{addrs: []string{"127.0.0.1"}}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewDNS returned error: %v", err)
+	}
+	out, err := yaml.Marshal(d)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if !strings.Contains(string(out), "127.0.0.1") {
+		t.Errorf("marshalled yaml is missing the addrs value:\n%s", out)
+	}
+}

--- a/resource/interface.go
+++ b/resource/interface.go
@@ -76,7 +76,9 @@ func NewInterface(sysInterface system.Interface, config util.Config) (*Interface
 		Exists: exists,
 	}
 	if !contains(config.IgnoreList, "addrs") {
-		if addrs, err := sysInterface.Addrs(); err == nil {
+		// An empty list asserts nothing, so leave Addrs unset and let omitempty
+		// drop it rather than generating `addrs: []`.
+		if addrs, err := sysInterface.Addrs(); err == nil && len(addrs) > 0 {
 			i.Addrs = addrs
 		}
 	}

--- a/resource/interface_test.go
+++ b/resource/interface_test.go
@@ -1,0 +1,57 @@
+package resource
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goss-org/goss/util"
+	"gopkg.in/yaml.v3"
+)
+
+// fakeSysInterface is a minimal system.Interface implementation used to drive
+// NewInterface without touching real network interfaces.
+type fakeSysInterface struct {
+	addrs []string
+}
+
+func (f *fakeSysInterface) Name() string             { return "eth0" }
+func (f *fakeSysInterface) Exists() (bool, error)    { return true, nil }
+func (f *fakeSysInterface) Addrs() ([]string, error) { return f.addrs, nil }
+func (f *fakeSysInterface) MTU() (int, error)        { return 1500, nil }
+
+// TestNewInterfaceLeavesAddrsUnsetWhenEmpty pins the same empty-list problem as
+// the file and http generators: an interface with no assigned addresses must
+// not produce `addrs: []`, which asserts nothing.
+func TestNewInterfaceLeavesAddrsUnsetWhenEmpty(t *testing.T) {
+	i, err := NewInterface(&fakeSysInterface{addrs: nil}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewInterface returned error: %v", err)
+	}
+	if i.Addrs != nil {
+		t.Errorf("NewInterface().Addrs = %#v, want nil", i.Addrs)
+	}
+
+	out, err := yaml.Marshal(i)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(out), "addrs:") {
+		t.Errorf("marshalled yaml contains an addrs key, want it omitted:\n%s", out)
+	}
+}
+
+// TestNewInterfaceKeepsAddrsWhenPresent makes sure the empty-list guard does
+// not drop real values.
+func TestNewInterfaceKeepsAddrsWhenPresent(t *testing.T) {
+	i, err := NewInterface(&fakeSysInterface{addrs: []string{"10.0.0.1/24"}}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewInterface returned error: %v", err)
+	}
+	out, err := yaml.Marshal(i)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if !strings.Contains(string(out), "10.0.0.1/24") {
+		t.Errorf("marshalled yaml is missing the addrs value:\n%s", out)
+	}
+}

--- a/resource/port.go
+++ b/resource/port.go
@@ -70,7 +70,9 @@ func NewPort(sysPort system.Port, config util.Config) (*Port, error) {
 		Listening: listening,
 	}
 	if !contains(config.IgnoreList, "ip") {
-		if ip, err := sysPort.IP(); err == nil {
+		// An empty list asserts nothing, so leave IP unset and let omitempty
+		// drop it rather than generating `ip: []`.
+		if ip, err := sysPort.IP(); err == nil && len(ip) > 0 {
 			p.IP = ip
 		}
 	}

--- a/resource/port_test.go
+++ b/resource/port_test.go
@@ -1,0 +1,58 @@
+package resource
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goss-org/goss/util"
+	"gopkg.in/yaml.v3"
+)
+
+// fakeSysPort is a minimal system.Port implementation used to drive NewPort
+// without inspecting the real network stack.
+type fakeSysPort struct {
+	ips []string
+}
+
+func (f *fakeSysPort) Port() string             { return "tcp:9999" }
+func (f *fakeSysPort) Exists() (bool, error)    { return false, nil }
+func (f *fakeSysPort) Listening() (bool, error) { return false, nil }
+func (f *fakeSysPort) IP() ([]string, error)    { return f.ips, nil }
+
+// TestNewPortLeavesIPUnsetWhenEmpty pins the fix for `goss add port` writing
+// `ip: []` into generated gossfiles for a port nothing is listening on. An
+// empty list asserts nothing, so NewPort must leave IP nil (matching the
+// field's yaml:"ip,omitempty" tag) rather than assigning the empty slice.
+func TestNewPortLeavesIPUnsetWhenEmpty(t *testing.T) {
+	p, err := NewPort(&fakeSysPort{ips: nil}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewPort returned error: %v", err)
+	}
+	if p.IP != nil {
+		t.Errorf("NewPort().IP = %#v, want nil", p.IP)
+	}
+
+	out, err := yaml.Marshal(p)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(out), "ip:") {
+		t.Errorf("marshalled yaml contains an ip key, want it omitted:\n%s", out)
+	}
+}
+
+// TestNewPortKeepsIPWhenPresent makes sure the empty-list guard does not drop
+// real values.
+func TestNewPortKeepsIPWhenPresent(t *testing.T) {
+	p, err := NewPort(&fakeSysPort{ips: []string{"0.0.0.0"}}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewPort returned error: %v", err)
+	}
+	out, err := yaml.Marshal(p)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if !strings.Contains(string(out), "0.0.0.0") {
+		t.Errorf("marshalled yaml is missing the ip value:\n%s", out)
+	}
+}

--- a/resource/user.go
+++ b/resource/user.go
@@ -98,7 +98,9 @@ func NewUser(sysUser system.User, config util.Config) (*User, error) {
 		}
 	}
 	if !contains(config.IgnoreList, "groups") {
-		if groups, err := sysUser.Groups(); err == nil {
+		// An empty list asserts nothing, so leave Groups unset and let omitempty
+		// drop it rather than generating `groups: []`.
+		if groups, err := sysUser.Groups(); err == nil && len(groups) > 0 {
 			u.Groups = groups
 		}
 	}

--- a/resource/user_test.go
+++ b/resource/user_test.go
@@ -1,0 +1,60 @@
+package resource
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goss-org/goss/util"
+	"gopkg.in/yaml.v3"
+)
+
+// fakeSysUser is a minimal system.User implementation used to drive NewUser
+// without reading the real passwd/group databases.
+type fakeSysUser struct {
+	groups []string
+}
+
+func (f *fakeSysUser) Username() string          { return "nobody" }
+func (f *fakeSysUser) Exists() (bool, error)     { return true, nil }
+func (f *fakeSysUser) UID() (int, error)         { return 65534, nil }
+func (f *fakeSysUser) GID() (int, error)         { return 65534, nil }
+func (f *fakeSysUser) Groups() ([]string, error) { return f.groups, nil }
+func (f *fakeSysUser) Home() (string, error)     { return "/nonexistent", nil }
+func (f *fakeSysUser) Shell() (string, error)    { return "/usr/sbin/nologin", nil }
+
+// TestNewUserLeavesGroupsUnsetWhenEmpty pins the same empty-list problem as the
+// file and http generators: a user belonging to no group must not produce
+// `groups: []`, which asserts nothing.
+func TestNewUserLeavesGroupsUnsetWhenEmpty(t *testing.T) {
+	u, err := NewUser(&fakeSysUser{groups: nil}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewUser returned error: %v", err)
+	}
+	if u.Groups != nil {
+		t.Errorf("NewUser().Groups = %#v, want nil", u.Groups)
+	}
+
+	out, err := yaml.Marshal(u)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if strings.Contains(string(out), "groups:") {
+		t.Errorf("marshalled yaml contains a groups key, want it omitted:\n%s", out)
+	}
+}
+
+// TestNewUserKeepsGroupsWhenPresent makes sure the empty-list guard does not
+// drop real values.
+func TestNewUserKeepsGroupsWhenPresent(t *testing.T) {
+	u, err := NewUser(&fakeSysUser{groups: []string{"nogroup"}}, util.Config{})
+	if err != nil {
+		t.Fatalf("NewUser returned error: %v", err)
+	}
+	out, err := yaml.Marshal(u)
+	if err != nil {
+		t.Fatalf("yaml.Marshal returned error: %v", err)
+	}
+	if !strings.Contains(string(out), "nogroup") {
+		t.Errorf("marshalled yaml is missing the groups value:\n%s", out)
+	}
+}


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this (the Makefile has no `test-all` target; ran `make test-short-all`, which is `fmt lint vet test`, all green, plus `golangci-lint run` explicitly since the make step could not find the binary on PATH: `0 issues.`. The Docker-based `integration-tests/test.sh` that diffs the updated fixtures was not run here)
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable) (no docs change needed, this removes an empty list from generated output and does not alter documented behaviour)

### Description of change

Same defect as #1111 and #1112, at the three remaining generators of that shape plus `user`. No separate issue is filed for this one.

## What's broken

Four more generators write an empty list into the gossfile they produce, so validating goss's own output warns about it.

```
$ goss -g out.yaml add port tcp:9999
port:
    tcp:9999:
        listening: false
        ip: []

$ goss -g out.yaml validate
WARNING: tcp:9999: port.ip is an empty list, which asserts nothing and always passes.
```

Same for `add dns` on a host that does not resolve, `add interface` on an interface with no addresses, and `add user` for a user in no groups.

## The fix

The fields are declared `matcher`, which is `any`, with `omitempty`. Assigning a typed nil slice into an `any` leaves the interface value non-nil, so `omitempty` does not fire and yaml.v3 writes `[]`:

```
nil []string in an `any` field -> "a: []"
untyped nil                    -> "{}"
```

So each generator now only assigns when the slice is non-empty, letting `omitempty` drop the key. The system getters that produce these are `DefPort.IP` (`var ips []string`, no append when the port has no entries), `DefDNS.Addrs` (`d.addrs` stays nil for an unresolvable host), `DefInterface.Addrs` (`var ret []string`), and `Groups`, where the unix path starts from `[]string{}`, non-nil and empty, and the windows path can return nil.

Ruled out and left alone: `mount.opts` and `mount.vfs-opts`, because a mounted filesystem always carries at least `rw` or `ro` and `setup()` errors out for a missing mountpoint, and `service.runlevels`, which `NewService` never assigns in the first place.

## Fixtures

`integration-tests/goss/*/goss-expected.yaml` carried `ip: []` for `tcp:9999` and `tcp6:80` on four distros. Those files are generated output diffed by `integration-tests/test.sh` under Docker, which `go test` does not run, so they are updated here the same way #1112 updated them. The hand-written inputs, and the `opts: []` entries under `tests/`, which sit behind `skip: true`, are untouched.

## Verification

A regression test per field asserting the key is absent from the marshalled yaml, plus a companion asserting a real value still survives, driven by minimal fake `system.*` implementations in the #1112 style. With the four guards reverted all four regression tests fail and all four companions still pass. `go test ./...` passes.

*Disclosure: written with AI assistance (Claude Code). I reproduced the issue, ran the change and the verification myself.*