### PR TITLE
fix(http): stop a request-header without a space after the colon panicking

### DIFF
--- a/resource/file_test.go
+++ b/resource/file_test.go
@@ -1,7 +1,6 @@
 package resource
 
 import (
-	"context"
 	"strings"
 	"testing"
 
@@ -11,10 +10,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// NewFile used to set Contents to an empty list, so every generated gossfile
-// warned about asserting nothing. It must stay unset and marshal away.
+// Contents must stay unset and marshal away: an empty list asserts nothing, so
+// every generated gossfile would warn about it.
 func TestNewFileLeavesContentsUnset(t *testing.T) {
-	sysFile := system.NewDefFile(context.Background(), "/etc/hostname", nil, util.Config{})
+	sysFile := system.NewDefFile(t.Context(), "/etc/hostname", nil, util.Config{})
 	f, err := NewFile(sysFile, util.Config{})
 	if err != nil {
 		t.Fatal(err)

--- a/system/http.go
+++ b/system/http.go
@@ -6,6 +6,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -59,7 +60,7 @@ func NewDefHTTP(_ context.Context, httpStr string, system *System, config util.C
 	for _, r := range config.RequestHeader {
 		name, value, found := strings.Cut(r, ":")
 		if !found {
-			fmt.Fprintf(os.Stderr, "WARNING: ignoring malformed request header %q, expected \"Name: value\"\n", r)
+			log.Printf("[WARNING] ignoring malformed request header %q, expected \"Name: value\"", r)
 			continue
 		}
 		headers.Add(strings.TrimSpace(name), strings.TrimSpace(value))

--- a/system/http.go
+++ b/system/http.go
@@ -57,8 +57,12 @@ func NewDefHTTP(_ context.Context, httpStr string, system *System, config util.C
 	}
 
 	for _, r := range config.RequestHeader {
-		str := strings.SplitN(r, ": ", 2)
-		headers.Add(str[0], str[1])
+		name, value, found := strings.Cut(r, ":")
+		if !found {
+			fmt.Fprintf(os.Stderr, "WARNING: ignoring malformed request header %q, expected \"Name: value\"\n", r)
+			continue
+		}
+		headers.Add(strings.TrimSpace(name), strings.TrimSpace(value))
 	}
 	return &DefHTTP{
 		http:              httpStr,

--- a/system/http_test.go
+++ b/system/http_test.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"context"
 	"io"
 	"net/http"
 	"strings"
@@ -60,7 +59,7 @@ func TestNewDefHTTPRequestHeaderParsing(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			h := NewDefHTTP(context.Background(), "http://example.com", nil, util.Config{
+			h := NewDefHTTP(t.Context(), "http://example.com", nil, util.Config{
 				RequestHeader: []string{tc.header},
 			})
 			def, ok := h.(*DefHTTP)

--- a/system/http_test.go
+++ b/system/http_test.go
@@ -1,10 +1,13 @@
 package system
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/goss-org/goss/util"
 )
 
 type trackingReadCloser struct {
@@ -38,5 +41,35 @@ func TestDefHTTPCloseClosesBodyAfterBodyRead(t *testing.T) {
 	}
 	if !body.closed {
 		t.Fatal("Close() did not close the response body")
+	}
+}
+
+// TestNewDefHTTPRequestHeaderParsing pins that request-headers entries are
+// parsed on the first colon, so the HTTP wire form "Name:value" works, and
+// that an entry with no colon is skipped instead of panicking.
+func TestNewDefHTTPRequestHeaderParsing(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{"colon and space", "X-Foo: bar", "bar"},
+		{"colon no space", "X-Foo:bar", "bar"},
+		{"no colon", "X-Foo", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := NewDefHTTP(context.Background(), "http://example.com", nil, util.Config{
+				RequestHeader: []string{tc.header},
+			})
+			def, ok := h.(*DefHTTP)
+			if !ok {
+				t.Fatalf("NewDefHTTP returned %T, want *DefHTTP", h)
+			}
+			if got := def.RequestHeader.Get("X-Foo"); got != tc.want {
+				t.Errorf("RequestHeader.Get(%q) = %q, want %q", "X-Foo", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this (the Makefile has no `test-all` target; ran `make test-short-all`, which is `fmt lint vet test`, all green, plus `golangci-lint run` explicitly since the make step could not find the binary on PATH: `0 issues.`)
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable) (the docs only show the well-formed `Key: value` spelling, which still behaves exactly as before, so nothing documented changes)

### Description of change

No matching issue is filed for this one; I found it while writing a request-header in the HTTP wire form.

## What's broken

A `request-headers` entry written in the HTTP wire form, with no space after the colon, panics the whole run.

```
http:
  http://127.0.0.1:9/:
    status: 200
    request-headers:
      - "X-Foo:bar"
```

```
$ goss validate
panic: runtime error: index out of range [1] with length 1
	github.com/goss-org/goss/system.NewDefHTTP(...) system/http.go:61
	github.com/goss-org/goss/resource.(*HTTP).Validate(...) resource/http.go:71
```

An entry with no colon at all panics identically. `"X-Foo:  bar"`, with two spaces, happens to work.

## The fix

```go
str := strings.SplitN(r, ": ", 2)
headers.Add(str[0], str[1])
```

The separator is the two-character string `": "`, so anything not matching that exact shape returns a one-element slice and `str[1]` is out of range. Nothing validates the entry beforehand, and the docs only show the well-formed spelling, so writing a header the way HTTP itself writes it gets you a stack trace.

It now cuts on the first `:` and trims both halves, which accepts `X-Foo:bar` and leaves `X-Foo: bar` behaving exactly as before. That matches `hasUserAgentHeader` a few lines up, which already prefix-matches on `"user-agent:"` without requiring the space.

An entry with no colon cannot become a header pair at all, so it is skipped with a warning on stderr rather than indexed. `NewDefHTTP` returns no error and its callers consume the value directly, so returning one would mean changing the `System.NewHTTP` func type and every call site. Warning and continuing is what the codebase already does for other unusable input, in `resource/resource.go`.

## Verification

Table-driven cases in `system/http_test.go` for the colon-space form, the no-space form and the no-colon form, asserting the resulting header values. With the change reverted the no-space case panics with the message above. `go test ./...` passes. `integration-tests/goss/goss-shared.yaml` uses `"Foo: bar"`, which is unaffected.

*Disclosure: written with AI assistance (Claude Code). I reproduced the issue, ran the change and the verification myself.*