### PR TITLE
Pass context through from the top-level consistently

### DIFF
--- a/add.go
+++ b/add.go
@@ -1,6 +1,7 @@
 package goss
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -12,7 +13,7 @@ import (
 )
 
 // AddResources is a simple wrapper to add multiple resources
-func AddResources(fileName, resourceName string, keys []string, c *util.Config) error {
+func AddResources(ctx context.Context, fileName, resourceName string, keys []string, c *util.Config) error {
 	if err := setLogLevel(c); err != nil {
 		return err
 	}
@@ -35,7 +36,7 @@ func AddResources(fileName, resourceName string, keys []string, c *util.Config) 
 	sys := system.New(c.PackageManager)
 
 	for _, key := range keys {
-		if err := AddResource(fileName, gossConfig, resourceName, key, *c, sys); err != nil {
+		if err := AddResource(ctx, fileName, gossConfig, resourceName, key, *c, sys); err != nil {
 			return err
 		}
 	}
@@ -44,44 +45,44 @@ func AddResources(fileName, resourceName string, keys []string, c *util.Config) 
 }
 
 // AddResource adds a single resource to fileName
-func AddResource(fileName string, gossConfig GossConfig, resourceName, key string, config util.Config, sys *system.System) error {
+func AddResource(ctx context.Context, fileName string, gossConfig GossConfig, resourceName, key string, config util.Config, sys *system.System) error {
 	var err error
 	var res resource.ResourceRead
 
 	// Need to figure out a good way to refactor this
 	switch resourceName {
 	case resource.AddResourceName:
-		res, err = gossConfig.Addrs.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Addrs.AppendSysResource(ctx, key, sys, config)
 	case resource.CommandResourceName:
-		res, err = gossConfig.Commands.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Commands.AppendSysResource(ctx, key, sys, config)
 	case resource.DNSResourceName:
-		res, err = gossConfig.DNS.AppendSysResource(key, sys, config)
+		res, err = gossConfig.DNS.AppendSysResource(ctx, key, sys, config)
 	case resource.FileResourceName:
-		res, err = gossConfig.Files.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Files.AppendSysResource(ctx, key, sys, config)
 	case resource.GroupResourceName:
-		res, err = gossConfig.Groups.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Groups.AppendSysResource(ctx, key, sys, config)
 	case resource.PackageResourceName:
-		res, err = gossConfig.Packages.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Packages.AppendSysResource(ctx, key, sys, config)
 	case resource.PortResourceName:
-		res, err = gossConfig.Ports.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Ports.AppendSysResource(ctx, key, sys, config)
 	case resource.ProcessResourceName:
-		res, err = gossConfig.Processes.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Processes.AppendSysResource(ctx, key, sys, config)
 	case resource.ServiceResourceName:
-		res, err = gossConfig.Services.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Services.AppendSysResource(ctx, key, sys, config)
 	case resource.UserResourceName:
-		res, err = gossConfig.Users.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Users.AppendSysResource(ctx, key, sys, config)
 	case resource.GossFileResourceName:
-		res, err = gossConfig.Gossfiles.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Gossfiles.AppendSysResource(ctx, key, sys, config)
 	case resource.KernelParamResourceName:
-		res, err = gossConfig.KernelParams.AppendSysResource(key, sys, config)
+		res, err = gossConfig.KernelParams.AppendSysResource(ctx, key, sys, config)
 	case resource.MountResourceName:
-		res, err = gossConfig.Mounts.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Mounts.AppendSysResource(ctx, key, sys, config)
 	case resource.InterfaceResourceName:
-		res, err = gossConfig.Interfaces.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Interfaces.AppendSysResource(ctx, key, sys, config)
 	case resource.HTTPResourceName:
-		res, err = gossConfig.HTTPs.AppendSysResource(key, sys, config)
+		res, err = gossConfig.HTTPs.AppendSysResource(ctx, key, sys, config)
 	case resource.RegistryResourceName:
-		res, err = gossConfig.Registries.AppendSysResource(key, sys, config)
+		res, err = gossConfig.Registries.AppendSysResource(ctx, key, sys, config)
 	default:
 		err = fmt.Errorf("undefined resource name: %s", resourceName)
 	}
@@ -96,7 +97,7 @@ func AddResource(fileName string, gossConfig GossConfig, resourceName, key strin
 }
 
 // AutoAddResources is a simple wrapper to add multiple resources
-func AutoAddResources(fileName string, keys []string, c *util.Config) error {
+func AutoAddResources(ctx context.Context, fileName string, keys []string, c *util.Config) error {
 	format, err := getStoreFormatFromFileName(fileName)
 	if err != nil {
 		return err
@@ -116,7 +117,7 @@ func AutoAddResources(fileName string, keys []string, c *util.Config) error {
 	sys := system.New(c.PackageManager)
 
 	for _, key := range keys {
-		if err := AutoAddResource(fileName, gossConfig, key, c, sys); err != nil {
+		if err := AutoAddResource(ctx, fileName, gossConfig, key, c, sys); err != nil {
 			return err
 		}
 	}
@@ -125,10 +126,10 @@ func AutoAddResources(fileName string, keys []string, c *util.Config) error {
 }
 
 // AutoAddResource adds a single resource to fileName with automatic detection of the type of resource
-func AutoAddResource(fileName string, gossConfig GossConfig, key string, c *util.Config, sys *system.System) error {
+func AutoAddResource(ctx context.Context, fileName string, gossConfig GossConfig, key string, c *util.Config, sys *system.System) error {
 	// file
 	if strings.Contains(key, "/") {
-		res, _, ok, err := gossConfig.Files.AppendSysResourceIfExists(key, sys)
+		res, _, ok, err := gossConfig.Files.AppendSysResourceIfExists(ctx, key, sys)
 		if err != nil {
 			return err
 		}
@@ -138,32 +139,28 @@ func AutoAddResource(fileName string, gossConfig GossConfig, key string, c *util
 	}
 
 	// group
-	if res, _, ok, err := gossConfig.Groups.AppendSysResourceIfExists(key, sys); err != nil {
+	if res, _, ok, err := gossConfig.Groups.AppendSysResourceIfExists(ctx, key, sys); err != nil {
 		return err
-
 	} else if ok {
 		resourcePrint(fileName, res, c.AnnounceToCLI)
 	}
 
 	// package
-	if res, _, ok, err := gossConfig.Packages.AppendSysResourceIfExists(key, sys); err != nil {
-
+	if res, _, ok, err := gossConfig.Packages.AppendSysResourceIfExists(ctx, key, sys); err != nil {
 		return err
-
 	} else if ok {
 		resourcePrint(fileName, res, c.AnnounceToCLI)
 	}
 
 	// port
-	if res, _, ok, err := gossConfig.Ports.AppendSysResourceIfExists(key, sys); err != nil {
+	if res, _, ok, err := gossConfig.Ports.AppendSysResourceIfExists(ctx, key, sys); err != nil {
 		return err
-
 	} else if ok {
 		resourcePrint(fileName, res, c.AnnounceToCLI)
 	}
 
 	// process
-	if res, sysres, ok, err := gossConfig.Processes.AppendSysResourceIfExists(key, sys); err != nil {
+	if res, sysres, ok, err := gossConfig.Processes.AppendSysResourceIfExists(ctx, key, sys); err != nil {
 		return err
 	} else if ok {
 		resourcePrint(fileName, res, c.AnnounceToCLI)
@@ -175,7 +172,7 @@ func AutoAddResource(fileName string, gossConfig GossConfig, key string, c *util
 				for _, entry := range entries {
 					if entry.Pid == pidS {
 						// port
-						if res, _, ok, err := gossConfig.Ports.AppendSysResourceIfExists(port, sys); err != nil {
+						if res, _, ok, err := gossConfig.Ports.AppendSysResourceIfExists(ctx, port, sys); err != nil {
 							return err
 						} else if ok {
 							resourcePrint(fileName, res, c.AnnounceToCLI)
@@ -187,14 +184,14 @@ func AutoAddResource(fileName string, gossConfig GossConfig, key string, c *util
 	}
 
 	// Service
-	if res, _, ok, err := gossConfig.Services.AppendSysResourceIfExists(key, sys); err != nil {
+	if res, _, ok, err := gossConfig.Services.AppendSysResourceIfExists(ctx, key, sys); err != nil {
 		return err
 	} else if ok {
 		resourcePrint(fileName, res, c.AnnounceToCLI)
 	}
 
 	// user
-	if res, _, ok, err := gossConfig.Users.AppendSysResourceIfExists(key, sys); err != nil {
+	if res, _, ok, err := gossConfig.Users.AppendSysResourceIfExists(ctx, key, sys); err != nil {
 		return err
 	} else if ok {
 		resourcePrint(fileName, res, c.AnnounceToCLI)

--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -153,7 +153,7 @@ func main() {
 				},
 				Action: func(ctx context.Context, c *cli.Command) error {
 					fatalAlphaIfNeeded(c)
-					code, err := goss.Validate(newRuntimeConfigFromCLI(c))
+					code, err := goss.Validate(ctx, newRuntimeConfigFromCLI(c))
 					if err != nil {
 						color.Red(fmt.Sprintf("Error: %v\n", err))
 					}
@@ -242,7 +242,7 @@ func main() {
 				Usage:   "automatically add all matching resource to the test suite",
 				Action: func(ctx context.Context, c *cli.Command) error {
 					fatalAlphaIfNeeded(c)
-					return goss.AutoAddResources(c.String("gossfile"), c.Args().Slice(), newRuntimeConfigFromCLI(c))
+					return goss.AutoAddResources(ctx, c.String("gossfile"), c.Args().Slice(), newRuntimeConfigFromCLI(c))
 				},
 			},
 			{
@@ -261,7 +261,7 @@ func main() {
 						Usage: "add new package",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.PackageResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.PackageResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -269,7 +269,7 @@ func main() {
 						Usage: "add new file",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.FileResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.FileResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -280,7 +280,7 @@ func main() {
 						},
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.AddResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.AddResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -288,7 +288,7 @@ func main() {
 						Usage: "add new listening [protocol]:port - ex: 80 or udp:123",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.PortResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.PortResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -296,7 +296,7 @@ func main() {
 						Usage: "add new service",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.ServiceResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.ServiceResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -304,7 +304,7 @@ func main() {
 						Usage: "add new user",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.UserResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.UserResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -312,7 +312,7 @@ func main() {
 						Usage: "add new group",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.GroupResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.GroupResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -323,7 +323,7 @@ func main() {
 						},
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.CommandResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.CommandResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -338,7 +338,7 @@ func main() {
 						},
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.DNSResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.DNSResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -346,7 +346,7 @@ func main() {
 						Usage: "add new process name",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.ProcessResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.ProcessResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -380,7 +380,7 @@ func main() {
 						},
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.HTTPResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.HTTPResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -388,7 +388,7 @@ func main() {
 						Usage: "add new goss file, it will be imported from this one",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.GossFileResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.GossFileResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 
 						},
 					},
@@ -397,7 +397,7 @@ func main() {
 						Usage: "add new goss kernel param",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.KernelParamResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.KernelParamResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -408,7 +408,7 @@ func main() {
 						},
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.MountResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.MountResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -416,7 +416,7 @@ func main() {
 						Usage: "add new interface",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.InterfaceResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.InterfaceResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 					{
@@ -424,7 +424,7 @@ func main() {
 						Usage: "add new registry key",
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)
-							return goss.AddResources(c.String("gossfile"), resource.RegistryResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
+							return goss.AddResources(ctx, c.String("gossfile"), resource.RegistryResourceName, c.Args().Slice(), newRuntimeConfigFromCLI(c))
 						},
 					},
 				},

--- a/goss_test.go
+++ b/goss_test.go
@@ -59,6 +59,7 @@ func TestConfigMerge(t *testing.T) {
 }
 
 func TestUseAsPackage(t *testing.T) {
+	ctx := t.Context()
 	output := &bytes.Buffer{}
 
 	// temp spec file
@@ -71,11 +72,11 @@ func TestUseAsPackage(t *testing.T) {
 	checkErr(t, err, "new config failed")
 
 	// adds the os tmp dir to the goss spec file
-	err = AddResources(fh.Name(), "File", []string{os.TempDir()}, cfg)
+	err = AddResources(ctx, fh.Name(), "File", []string{os.TempDir()}, cfg)
 	checkErr(t, err, "could not add resource %q", os.TempDir())
 
 	// validate and sanity check, compare structured vs direct results etc
-	results, err := ValidateResults(cfg)
+	results, err := ValidateResults(ctx, cfg)
 	checkErr(t, err, "check failed")
 
 	found := 0
@@ -90,7 +91,7 @@ func TestUseAsPackage(t *testing.T) {
 		}
 	}
 
-	code, err := Validate(cfg)
+	code, err := Validate(ctx, cfg)
 	checkErr(t, err, "check failed")
 	if code != 0 {
 		t.Fatalf("check failed, expected 0 got %d", code)
@@ -121,6 +122,7 @@ func TestUseAsPackage(t *testing.T) {
 }
 
 func TestSkipResourcesByType(t *testing.T) {
+	ctx := t.Context()
 	output := &bytes.Buffer{}
 
 	// temp spec file
@@ -133,11 +135,11 @@ func TestSkipResourcesByType(t *testing.T) {
 	checkErr(t, err, "new config failed")
 
 	// adds the os tmp dir to the goss spec file
-	err = AddResources(fh.Name(), "File", []string{os.TempDir()}, cfg)
+	err = AddResources(ctx, fh.Name(), "File", []string{os.TempDir()}, cfg)
 	checkErr(t, err, "could not add resource %q", os.TempDir())
 
 	// validate and sanity check, compare structured vs direct results etc
-	results, err := ValidateResults(cfg)
+	results, err := ValidateResults(ctx, cfg)
 	checkErr(t, err, "check failed")
 
 	skipped := 0

--- a/matcher_test.go
+++ b/matcher_test.go
@@ -29,6 +29,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestMatchers(t *testing.T) {
+	ctx := t.Context()
 	files, err := filepath.Glob(filepath.Join("testdata", "out_matching_*"))
 	if err != nil {
 		t.Fatal(err)
@@ -57,7 +58,7 @@ func TestMatchers(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			exitCode, err := Validate(cfg)
+			exitCode, err := Validate(ctx, cfg)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/resource/addr.go
+++ b/resource/addr.go
@@ -52,8 +52,8 @@ func (a *Addr) GetAddress() string {
 	return a.id
 }
 
-func (a *Addr) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, a.ID())
+func (a *Addr) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, a.ID())
 	skip := a.Skip
 
 	if a.Timeout == 0 {

--- a/resource/command.go
+++ b/resource/command.go
@@ -48,8 +48,8 @@ func (c *Command) GetExec() string {
 	return c.id
 }
 
-func (c *Command) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), system.CommandIDKey, c.ID())
+func (c *Command) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, system.CommandIDKey, c.ID())
 	skip := c.Skip
 
 	if c.Timeout == 0 {

--- a/resource/dns.go
+++ b/resource/dns.go
@@ -51,8 +51,8 @@ func (d *DNS) GetResolve() string {
 	return d.id
 }
 
-func (d *DNS) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, d.ID())
+func (d *DNS) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, d.ID())
 	skip := d.Skip
 	if d.Timeout == 0 {
 		d.Timeout = 500

--- a/resource/file.go
+++ b/resource/file.go
@@ -60,8 +60,8 @@ func (f *File) GetPath() string {
 	return f.id
 }
 
-func (f *File) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, f.ID())
+func (f *File) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, f.ID())
 	skip := f.Skip
 	sysFile := sys.NewFile(ctx, f.GetPath(), sys, util.Config{})
 

--- a/resource/gossfile.go
+++ b/resource/gossfile.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"context"
+
 	"github.com/goss-org/goss/system"
 	"github.com/goss-org/goss/util"
 )
@@ -40,7 +42,7 @@ func (g *Gossfile) GetGossfile() string {
 	return g.Path
 }
 
-func (g *Gossfile) Validate(sys *system.System) []TestResult {
+func (g *Gossfile) Validate(_ context.Context, _ *system.System) []TestResult {
 	return []TestResult{}
 }
 

--- a/resource/group.go
+++ b/resource/group.go
@@ -46,8 +46,8 @@ func (g *Group) GetGroupname() string {
 	return g.id
 }
 
-func (g *Group) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, g.ID())
+func (g *Group) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, g.ID())
 	skip := g.Skip
 	sysgroup := sys.NewGroup(ctx, g.GetGroupname(), sys, util.Config{})
 

--- a/resource/http.go
+++ b/resource/http.go
@@ -62,8 +62,8 @@ func (r *HTTP) getURL() string {
 	return r.id
 }
 
-func (u *HTTP) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, u.ID())
+func (u *HTTP) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, u.ID())
 	skip := u.Skip
 	if u.Timeout == 0 {
 		u.Timeout = 5000

--- a/resource/interface.go
+++ b/resource/interface.go
@@ -49,8 +49,8 @@ func (i *Interface) GetName() string {
 	return i.id
 }
 
-func (i *Interface) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, i.ID())
+func (i *Interface) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, i.ID())
 	skip := i.Skip
 	sysInterface := sys.NewInterface(ctx, i.GetName(), sys, util.Config{})
 

--- a/resource/kernel_param.go
+++ b/resource/kernel_param.go
@@ -49,8 +49,8 @@ func (k *KernelParam) GetName() string {
 	return k.id
 }
 
-func (k *KernelParam) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, k.ID())
+func (k *KernelParam) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, k.ID())
 	skip := k.Skip
 	sysKernelParam := sys.NewKernelParam(ctx, k.GetName(), sys, util.Config{})
 

--- a/resource/matching.go
+++ b/resource/matching.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -38,7 +39,7 @@ func (a *Matching) TypeName() string { return MatchingResourceName }
 func (r *Matching) GetTitle() string { return r.Title }
 func (r *Matching) GetMeta() meta    { return r.Meta }
 
-func (a *Matching) Validate(sys *system.System) []TestResult {
+func (a *Matching) Validate(_ context.Context, sys *system.System) []TestResult {
 	skip := a.Skip
 
 	var stub interface{}

--- a/resource/mount.go
+++ b/resource/mount.go
@@ -3,9 +3,10 @@ package resource
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/goss-org/goss/system"
 	"github.com/goss-org/goss/util"
-	"time"
 )
 
 type Mount struct {
@@ -53,8 +54,8 @@ func (m *Mount) GetMountPoint() string {
 	return m.id
 }
 
-func (m *Mount) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, m.ID())
+func (m *Mount) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, m.ID())
 	skip := m.Skip
 
 	if m.Timeout == 0 {

--- a/resource/package.go
+++ b/resource/package.go
@@ -46,8 +46,8 @@ func (p *Package) GetName() string {
 	return p.id
 }
 
-func (p *Package) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, p.ID())
+func (p *Package) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, p.ID())
 	skip := p.Skip
 	sysPkg := sys.NewPackage(ctx, p.GetName(), sys, util.Config{})
 

--- a/resource/port.go
+++ b/resource/port.go
@@ -46,8 +46,8 @@ func (p *Port) GetPort() string {
 	return p.id
 }
 
-func (p *Port) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, p.ID())
+func (p *Port) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, p.ID())
 	skip := p.Skip
 	sysPort := sys.NewPort(ctx, p.GetPort(), sys, util.Config{})
 

--- a/resource/process.go
+++ b/resource/process.go
@@ -45,8 +45,8 @@ func (p *Process) GetComm() string {
 	return p.id
 }
 
-func (p *Process) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, p.ID())
+func (p *Process) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, p.ID())
 	skip := p.Skip
 	sysProcess := sys.NewProcess(ctx, p.GetComm(), sys, util.Config{})
 

--- a/resource/registry.go
+++ b/resource/registry.go
@@ -48,8 +48,8 @@ func (r *Registry) GetName() string {
 	return r.id
 }
 
-func (r *Registry) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, r.ID())
+func (r *Registry) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, r.ID())
 	skip := r.Skip
 	sysRegistry := sys.NewRegistry(ctx, r.GetName(), sys, util.Config{})
 

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,7 @@ import (
 )
 
 type Resource interface {
-	Validate(sys *system.System) []TestResult
+	Validate(ctx context.Context, sys *system.System) []TestResult
 	SetID(string)
 	SetSkip()
 	TypeKey() string

--- a/resource/resource_list.go
+++ b/resource/resource_list.go
@@ -17,8 +17,8 @@ import (
 
 type AddrMap map[string]*Addr
 
-func (r AddrMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Addr, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r AddrMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Addr, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewAddr(ctx, sr, sys, config)
 	res, err := NewAddr(sysres, config)
 	if err != nil {
@@ -32,8 +32,8 @@ func (r AddrMap) AppendSysResource(sr string, sys *system.System, config util.Co
 	return res, nil
 }
 
-func (r AddrMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Addr, system.Addr, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r AddrMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Addr, system.Addr, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewAddr(ctx, sr, sys, util.Config{})
 	res, err := NewAddr(sysres, util.Config{})
 	if err != nil {
@@ -118,8 +118,8 @@ func (ret *AddrMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 
 type CommandMap map[string]*Command
 
-func (r CommandMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Command, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r CommandMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Command, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewCommand(ctx, sr, sys, config)
 	res, err := NewCommand(sysres, config)
 	if err != nil {
@@ -133,8 +133,8 @@ func (r CommandMap) AppendSysResource(sr string, sys *system.System, config util
 	return res, nil
 }
 
-func (r CommandMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Command, system.Command, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r CommandMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Command, system.Command, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewCommand(ctx, sr, sys, util.Config{})
 	res, err := NewCommand(sysres, util.Config{})
 	if err != nil {
@@ -219,8 +219,8 @@ func (ret *CommandMap) UnmarshalYAML(unmarshal func(v interface{}) error) error 
 
 type DNSMap map[string]*DNS
 
-func (r DNSMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*DNS, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r DNSMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*DNS, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewDNS(ctx, sr, sys, config)
 	res, err := NewDNS(sysres, config)
 	if err != nil {
@@ -234,8 +234,8 @@ func (r DNSMap) AppendSysResource(sr string, sys *system.System, config util.Con
 	return res, nil
 }
 
-func (r DNSMap) AppendSysResourceIfExists(sr string, sys *system.System) (*DNS, system.DNS, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r DNSMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*DNS, system.DNS, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewDNS(ctx, sr, sys, util.Config{})
 	res, err := NewDNS(sysres, util.Config{})
 	if err != nil {
@@ -320,8 +320,8 @@ func (ret *DNSMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 
 type FileMap map[string]*File
 
-func (r FileMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*File, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r FileMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*File, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewFile(ctx, sr, sys, config)
 	res, err := NewFile(sysres, config)
 	if err != nil {
@@ -335,8 +335,8 @@ func (r FileMap) AppendSysResource(sr string, sys *system.System, config util.Co
 	return res, nil
 }
 
-func (r FileMap) AppendSysResourceIfExists(sr string, sys *system.System) (*File, system.File, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r FileMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*File, system.File, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewFile(ctx, sr, sys, util.Config{})
 	res, err := NewFile(sysres, util.Config{})
 	if err != nil {
@@ -421,8 +421,8 @@ func (ret *FileMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 
 type GossfileMap map[string]*Gossfile
 
-func (r GossfileMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Gossfile, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r GossfileMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Gossfile, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewGossfile(ctx, sr, sys, config)
 	res, err := NewGossfile(sysres, config)
 	if err != nil {
@@ -436,8 +436,8 @@ func (r GossfileMap) AppendSysResource(sr string, sys *system.System, config uti
 	return res, nil
 }
 
-func (r GossfileMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Gossfile, system.Gossfile, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r GossfileMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Gossfile, system.Gossfile, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewGossfile(ctx, sr, sys, util.Config{})
 	res, err := NewGossfile(sysres, util.Config{})
 	if err != nil {
@@ -522,8 +522,8 @@ func (ret *GossfileMap) UnmarshalYAML(unmarshal func(v interface{}) error) error
 
 type GroupMap map[string]*Group
 
-func (r GroupMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Group, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r GroupMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Group, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewGroup(ctx, sr, sys, config)
 	res, err := NewGroup(sysres, config)
 	if err != nil {
@@ -537,8 +537,8 @@ func (r GroupMap) AppendSysResource(sr string, sys *system.System, config util.C
 	return res, nil
 }
 
-func (r GroupMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Group, system.Group, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r GroupMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Group, system.Group, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewGroup(ctx, sr, sys, util.Config{})
 	res, err := NewGroup(sysres, util.Config{})
 	if err != nil {
@@ -623,8 +623,8 @@ func (ret *GroupMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 
 type PackageMap map[string]*Package
 
-func (r PackageMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Package, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r PackageMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Package, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewPackage(ctx, sr, sys, config)
 	res, err := NewPackage(sysres, config)
 	if err != nil {
@@ -638,8 +638,8 @@ func (r PackageMap) AppendSysResource(sr string, sys *system.System, config util
 	return res, nil
 }
 
-func (r PackageMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Package, system.Package, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r PackageMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Package, system.Package, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewPackage(ctx, sr, sys, util.Config{})
 	res, err := NewPackage(sysres, util.Config{})
 	if err != nil {
@@ -724,8 +724,8 @@ func (ret *PackageMap) UnmarshalYAML(unmarshal func(v interface{}) error) error 
 
 type PortMap map[string]*Port
 
-func (r PortMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Port, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r PortMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Port, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewPort(ctx, sr, sys, config)
 	res, err := NewPort(sysres, config)
 	if err != nil {
@@ -739,8 +739,8 @@ func (r PortMap) AppendSysResource(sr string, sys *system.System, config util.Co
 	return res, nil
 }
 
-func (r PortMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Port, system.Port, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r PortMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Port, system.Port, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewPort(ctx, sr, sys, util.Config{})
 	res, err := NewPort(sysres, util.Config{})
 	if err != nil {
@@ -825,8 +825,8 @@ func (ret *PortMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 
 type ProcessMap map[string]*Process
 
-func (r ProcessMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Process, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r ProcessMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Process, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewProcess(ctx, sr, sys, config)
 	res, err := NewProcess(sysres, config)
 	if err != nil {
@@ -840,8 +840,8 @@ func (r ProcessMap) AppendSysResource(sr string, sys *system.System, config util
 	return res, nil
 }
 
-func (r ProcessMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Process, system.Process, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r ProcessMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Process, system.Process, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewProcess(ctx, sr, sys, util.Config{})
 	res, err := NewProcess(sysres, util.Config{})
 	if err != nil {
@@ -926,8 +926,8 @@ func (ret *ProcessMap) UnmarshalYAML(unmarshal func(v interface{}) error) error 
 
 type ServiceMap map[string]*Service
 
-func (r ServiceMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Service, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r ServiceMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Service, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewService(ctx, sr, sys, config)
 	res, err := NewService(sysres, config)
 	if err != nil {
@@ -941,8 +941,8 @@ func (r ServiceMap) AppendSysResource(sr string, sys *system.System, config util
 	return res, nil
 }
 
-func (r ServiceMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Service, system.Service, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r ServiceMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Service, system.Service, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewService(ctx, sr, sys, util.Config{})
 	res, err := NewService(sysres, util.Config{})
 	if err != nil {
@@ -1027,8 +1027,8 @@ func (ret *ServiceMap) UnmarshalYAML(unmarshal func(v interface{}) error) error 
 
 type UserMap map[string]*User
 
-func (r UserMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*User, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r UserMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*User, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewUser(ctx, sr, sys, config)
 	res, err := NewUser(sysres, config)
 	if err != nil {
@@ -1042,8 +1042,8 @@ func (r UserMap) AppendSysResource(sr string, sys *system.System, config util.Co
 	return res, nil
 }
 
-func (r UserMap) AppendSysResourceIfExists(sr string, sys *system.System) (*User, system.User, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r UserMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*User, system.User, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewUser(ctx, sr, sys, util.Config{})
 	res, err := NewUser(sysres, util.Config{})
 	if err != nil {
@@ -1128,8 +1128,8 @@ func (ret *UserMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 
 type KernelParamMap map[string]*KernelParam
 
-func (r KernelParamMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*KernelParam, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r KernelParamMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*KernelParam, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewKernelParam(ctx, sr, sys, config)
 	res, err := NewKernelParam(sysres, config)
 	if err != nil {
@@ -1143,8 +1143,8 @@ func (r KernelParamMap) AppendSysResource(sr string, sys *system.System, config 
 	return res, nil
 }
 
-func (r KernelParamMap) AppendSysResourceIfExists(sr string, sys *system.System) (*KernelParam, system.KernelParam, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r KernelParamMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*KernelParam, system.KernelParam, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewKernelParam(ctx, sr, sys, util.Config{})
 	res, err := NewKernelParam(sysres, util.Config{})
 	if err != nil {
@@ -1229,8 +1229,8 @@ func (ret *KernelParamMap) UnmarshalYAML(unmarshal func(v interface{}) error) er
 
 type MountMap map[string]*Mount
 
-func (r MountMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Mount, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r MountMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Mount, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewMount(ctx, sr, sys, config)
 	res, err := NewMount(sysres, config)
 	if err != nil {
@@ -1244,8 +1244,8 @@ func (r MountMap) AppendSysResource(sr string, sys *system.System, config util.C
 	return res, nil
 }
 
-func (r MountMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Mount, system.Mount, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r MountMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Mount, system.Mount, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewMount(ctx, sr, sys, util.Config{})
 	res, err := NewMount(sysres, util.Config{})
 	if err != nil {
@@ -1330,8 +1330,8 @@ func (ret *MountMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 
 type InterfaceMap map[string]*Interface
 
-func (r InterfaceMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Interface, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r InterfaceMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Interface, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewInterface(ctx, sr, sys, config)
 	res, err := NewInterface(sysres, config)
 	if err != nil {
@@ -1345,8 +1345,8 @@ func (r InterfaceMap) AppendSysResource(sr string, sys *system.System, config ut
 	return res, nil
 }
 
-func (r InterfaceMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Interface, system.Interface, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r InterfaceMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Interface, system.Interface, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewInterface(ctx, sr, sys, util.Config{})
 	res, err := NewInterface(sysres, util.Config{})
 	if err != nil {
@@ -1431,8 +1431,8 @@ func (ret *InterfaceMap) UnmarshalYAML(unmarshal func(v interface{}) error) erro
 
 type HTTPMap map[string]*HTTP
 
-func (r HTTPMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*HTTP, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r HTTPMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*HTTP, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewHTTP(ctx, sr, sys, config)
 	res, err := NewHTTP(sysres, config)
 	if err != nil {
@@ -1446,8 +1446,8 @@ func (r HTTPMap) AppendSysResource(sr string, sys *system.System, config util.Co
 	return res, nil
 }
 
-func (r HTTPMap) AppendSysResourceIfExists(sr string, sys *system.System) (*HTTP, system.HTTP, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r HTTPMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*HTTP, system.HTTP, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewHTTP(ctx, sr, sys, util.Config{})
 	res, err := NewHTTP(sysres, util.Config{})
 	if err != nil {
@@ -1532,8 +1532,8 @@ func (ret *HTTPMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
 
 type RegistryMap map[string]*Registry
 
-func (r RegistryMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*Registry, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r RegistryMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*Registry, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewRegistry(ctx, sr, sys, config)
 	res, err := NewRegistry(sysres, config)
 	if err != nil {
@@ -1547,8 +1547,8 @@ func (r RegistryMap) AppendSysResource(sr string, sys *system.System, config uti
 	return res, nil
 }
 
-func (r RegistryMap) AppendSysResourceIfExists(sr string, sys *system.System) (*Registry, system.Registry, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r RegistryMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*Registry, system.Registry, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewRegistry(ctx, sr, sys, util.Config{})
 	res, err := NewRegistry(sysres, util.Config{})
 	if err != nil {
@@ -1566,6 +1566,7 @@ func (r RegistryMap) AppendSysResourceIfExists(sr string, sys *system.System) (*
 }
 
 func (ret *RegistryMap) UnmarshalJSON(data []byte) error {
+	// Curried json.Unmarshal
 	unmarshal := func(i interface{}) error {
 		if err := json.Unmarshal(data, i); err != nil {
 			return err
@@ -1573,6 +1574,7 @@ func (ret *RegistryMap) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
+	// Validate configuration
 	zero := Registry{}
 	whitelist, err := util.WhitelistAttrs(zero, util.JSON)
 	if err != nil {
@@ -1601,6 +1603,7 @@ func (ret *RegistryMap) UnmarshalJSON(data []byte) error {
 }
 
 func (ret *RegistryMap) UnmarshalYAML(unmarshal func(v interface{}) error) error {
+	// Validate configuration
 	zero := Registry{}
 	whitelist, err := util.WhitelistAttrs(zero, util.YAML)
 	if err != nil {

--- a/resource/resource_list_genny.go
+++ b/resource/resource_list_genny.go
@@ -25,8 +25,8 @@ type ResourceType generic.Type
 
 type ResourceTypeMap map[string]*ResourceType
 
-func (r ResourceTypeMap) AppendSysResource(sr string, sys *system.System, config util.Config) (*ResourceType, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r ResourceTypeMap) AppendSysResource(ctx context.Context, sr string, sys *system.System, config util.Config) (*ResourceType, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewResourceType(ctx, sr, sys, config)
 	res, err := NewResourceType(sysres, config)
 	if err != nil {
@@ -40,8 +40,8 @@ func (r ResourceTypeMap) AppendSysResource(sr string, sys *system.System, config
 	return res, nil
 }
 
-func (r ResourceTypeMap) AppendSysResourceIfExists(sr string, sys *system.System) (*ResourceType, system.ResourceType, bool, error) {
-	ctx := context.WithValue(context.Background(), idKey{}, sr)
+func (r ResourceTypeMap) AppendSysResourceIfExists(ctx context.Context, sr string, sys *system.System) (*ResourceType, system.ResourceType, bool, error) {
+	ctx = context.WithValue(ctx, idKey{}, sr)
 	sysres := sys.NewResourceType(ctx, sr, sys, util.Config{})
 	res, err := NewResourceType(sysres, util.Config{})
 	if err != nil {

--- a/resource/retry_test.go
+++ b/resource/retry_test.go
@@ -207,7 +207,7 @@ func TestPackageValidateRetries(t *testing.T) {
 		RetryDelay: RetryDelay(10 * time.Millisecond),
 	}
 
-	results := pkg.Validate(sys)
+	results := pkg.Validate(t.Context(), sys)
 
 	if installedCalls != 2 {
 		t.Fatalf("expected installed to be retried once, got %d calls", installedCalls)
@@ -249,7 +249,7 @@ func TestDNSValidateRetries(t *testing.T) {
 		RetryDelay: RetryDelay(10 * time.Millisecond),
 	}
 
-	results := dns.Validate(sys)
+	results := dns.Validate(t.Context(), sys)
 
 	if resolvableCalls != 2 {
 		t.Fatalf("expected resolvable to be retried once, got %d calls", resolvableCalls)
@@ -304,7 +304,7 @@ func TestCommandValidateRetries(t *testing.T) {
 		RetryDelay: RetryDelay(10 * time.Millisecond),
 	}
 
-	results := cmd.Validate(sys)
+	results := cmd.Validate(t.Context(), sys)
 
 	if commandCalls != 2 {
 		t.Fatalf("expected command to be retried once, got %d attempts", commandCalls)

--- a/resource/service.go
+++ b/resource/service.go
@@ -47,8 +47,8 @@ func (s *Service) GetName() string {
 	return s.id
 }
 
-func (s *Service) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, s.ID())
+func (s *Service) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, s.ID())
 	skip := s.Skip
 	sysservice := sys.NewService(ctx, s.GetName(), sys, util.Config{})
 

--- a/resource/user.go
+++ b/resource/user.go
@@ -50,8 +50,8 @@ func (u *User) GetUsername() string {
 	return u.id
 }
 
-func (u *User) Validate(sys *system.System) []TestResult {
-	ctx := context.WithValue(context.Background(), idKey{}, u.ID())
+func (u *User) Validate(ctx context.Context, sys *system.System) []TestResult {
+	ctx = context.WithValue(ctx, idKey{}, u.ID())
 	skip := u.Skip
 	sysuser := sys.NewUser(ctx, u.GetUsername(), sys, util.Config{})
 

--- a/serve.go
+++ b/serve.go
@@ -2,6 +2,7 @@ package goss
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -90,7 +91,7 @@ func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	negotiatedContentType := h.responseContentType(outputFormat)
 
 	log.Printf("[TRACE] %v: requesting health probe", r.RemoteAddr)
-	resp := h.processAndEnsureCached(negotiatedContentType, outputer)
+	resp := h.processAndEnsureCached(r.Context(), negotiatedContentType, outputer)
 	w.Header().Set("Content-Type", negotiatedContentType)
 	w.WriteHeader(resp.statusCode)
 	logBody := ""
@@ -101,7 +102,7 @@ func (h healthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Printf("[DEBUG] %v: status %d%s", r.RemoteAddr, resp.statusCode, logBody)
 }
 
-func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outputer outputs.Outputer) res {
+func (h healthHandler) processAndEnsureCached(ctx context.Context, negotiatedContentType string, outputer outputs.Outputer) res {
 	var tra [][]resource.TestResult
 	cacheKey := "res"
 	// Held across the lookup so a miss does not let a second request start its
@@ -113,7 +114,7 @@ func (h healthHandler) processAndEnsureCached(negotiatedContentType string, outp
 	} else {
 		log.Printf(cacheMissLogFormat, cacheKey)
 		h.sys = system.New(h.c.PackageManager)
-		tra = h.validate()
+		tra = h.validate(ctx)
 		h.cache.SetDefault(cacheKey, tra)
 	}
 	h.gossMu.Unlock()
@@ -138,10 +139,10 @@ func (h healthHandler) output(trc <-chan []resource.TestResult, outputer outputs
 	}
 	return resp
 }
-func (h healthHandler) validate() [][]resource.TestResult {
+func (h healthHandler) validate(ctx context.Context) [][]resource.TestResult {
 	h.sys = system.New(h.c.PackageManager)
 	res := make([][]resource.TestResult, 0)
-	tr := validate(h.sys, h.gossConfig, h.c.DisabledResourceTypes, h.maxConcurrent)
+	tr := validate(ctx, h.sys, h.gossConfig, h.c.DisabledResourceTypes, h.maxConcurrent)
 	for i := range tr {
 		res = append(res, i)
 	}

--- a/validate.go
+++ b/validate.go
@@ -1,6 +1,7 @@
 package goss
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -87,7 +88,7 @@ func getOutputer(c *bool, format string) (outputs.Outputer, error) {
 
 // ValidateResults performs validation and provides programmatic access to validation results
 // no retries or outputs are supported
-func ValidateResults(c *util.Config) (results <-chan []resource.TestResult, err error) {
+func ValidateResults(ctx context.Context, c *util.Config) (results <-chan []resource.TestResult, err error) {
 	gossConfig, err := getGossConfig(c.VarsFiles, c.VarsInline, c.Spec)
 	if err != nil {
 		return nil, err
@@ -95,14 +96,14 @@ func ValidateResults(c *util.Config) (results <-chan []resource.TestResult, err 
 
 	sys := system.New(c.PackageManager)
 
-	return validate(sys, *gossConfig, c.DisabledResourceTypes, c.MaxConcurrent), nil
+	return validate(ctx, sys, *gossConfig, c.DisabledResourceTypes, c.MaxConcurrent), nil
 }
 
 // Validate performs validation, writes formatted output to stdout by default
 // and supports retries and more, this is the full featured Validate used
 // by the typical CLI invocation and will produce output to StdOut.  Use
 // ValidateResults for programmatic access
-func Validate(c *util.Config) (code int, err error) {
+func Validate(ctx context.Context, c *util.Config) (code int, err error) {
 	err = setLogLevel(c)
 	if err != nil {
 		return 1, err
@@ -111,10 +112,10 @@ func Validate(c *util.Config) (code int, err error) {
 	if err != nil {
 		return 78, err
 	}
-	return ValidateConfig(c, gossConfig)
+	return ValidateConfig(ctx, c, gossConfig)
 }
 
-func ValidateConfig(c *util.Config, gossConfig *GossConfig) (code int, err error) {
+func ValidateConfig(ctx context.Context, c *util.Config, gossConfig *GossConfig) (code int, err error) {
 	// Needed for contains-elements
 	// Maybe we don't use this and use custom
 	// contain_element_matcher is needed because it's single entry to avoid
@@ -141,7 +142,7 @@ func ValidateConfig(c *util.Config, gossConfig *GossConfig) (code int, err error
 	i := 1
 	startTime := time.Now()
 	for {
-		out := validate(sys, *gossConfig, c.DisabledResourceTypes, c.MaxConcurrent)
+		out := validate(ctx, sys, *gossConfig, c.DisabledResourceTypes, c.MaxConcurrent)
 		exitCode := outputer.Output(ofh, out, outputConfig)
 		if retryTimeout == 0 || exitCode == 0 {
 			return exitCode, nil
@@ -159,7 +160,7 @@ func ValidateConfig(c *util.Config, gossConfig *GossConfig) (code int, err error
 	}
 }
 
-func validate(sys *system.System, gossConfig GossConfig, skipList []string, maxConcurrent int) <-chan []resource.TestResult {
+func validate(ctx context.Context, sys *system.System, gossConfig GossConfig, skipList []string, maxConcurrent int) <-chan []resource.TestResult {
 	out := make(chan []resource.TestResult)
 	in := make(chan resource.Resource)
 
@@ -184,7 +185,7 @@ func validate(sys *system.System, gossConfig GossConfig, skipList []string, maxC
 		go func() {
 			defer wg.Done()
 			for f := range in {
-				out <- f.Validate(sys)
+				out <- f.Validate(ctx, sys)
 			}
 		}()
 	}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: ./CONTRIBUTING.md
-->

<!-- _Please make sure to review and check all of these items:_ -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Description of change
<!--
Please provide a description of the change here. Be sure to use issue references when applicable:
https://help.github.com/en/github/managing-your-work-on-github/closing-issues-using-keywords
-->

Closes #1090.

This updates the code to pass the root context down consistently from the top level when goss is run for one-shot checks and also passes the request context down when running as a server. The tests have also been fixed up to use the context provided by `testing.T` in most spots (the only exception is being handled in #1115).