### PR TITLE
fix(matchers): an empty map matcher panics instead of reporting a syntax error

### DIFF
--- a/resource/gomega.go
+++ b/resource/gomega.go
@@ -8,7 +8,10 @@ import (
 	"github.com/samber/lo"
 )
 
-var errMissingRequiredAttribute = errors.New("Syntax Error: Missing required attribute")
+var (
+	errMissingRequiredAttribute = errors.New("Syntax Error: Missing required attribute")
+	errEmptyMatcher             = errors.New("Syntax Error: Invalid matcher configuration. An empty map asserts nothing, exactly one matcher is required")
+)
 
 func matcherToGomegaMatcher(matcher any) (matchers.GossMatcher, error) {
 	// Default matchers
@@ -39,6 +42,9 @@ func matcherToGomegaMatcher(matcher any) (matchers.GossMatcher, error) {
 		//panic(fmt.Sprintf("Syntax Error: Unexpected matcher type: %T\n\n", matcher))
 	}
 	keys := lo.Keys(matcherMap)
+	if len(keys) == 0 {
+		return nil, errEmptyMatcher
+	}
 	if len(keys) > 1 {
 		return nil, fmt.Errorf("Syntax Error: Invalid matcher configuration. At a given nesting level, only one matcher is allowed. Found multiple matchers: %q", keys)
 	}

--- a/resource/gomega_test.go
+++ b/resource/gomega_test.go
@@ -162,3 +162,29 @@ func TestMatcherToGomegaMatcher(t *testing.T) {
 func gomegaTestEqual(t *testing.T, got, want any, useNegateTester bool, in string) {
 	assert.Equal(t, got, want)
 }
+
+// An empty matcher map used to panic with an index out of range instead of
+// being reported as a syntax error.
+func TestMatcherToGomegaMatcherEmptyMap(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{name: "top level", in: `{}`},
+		{name: "nested in and", in: `{"and": [{}]}`},
+		{name: "nested in not", in: `{"not": {}}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var dat any
+			if err := json.Unmarshal([]byte(c.in), &dat); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := matcherToGomegaMatcher(dat)
+			assert.Nil(t, got)
+			assert.ErrorIs(t, err, errEmptyMatcher)
+		})
+	}
+}


### PR DESCRIPTION
An empty map used as a matcher crashes goss instead of reporting a syntax error.

```yaml
command:
  echo hi:
    exit-status: 0
    stdout: {}
```

```
before:
panic: runtime error: index out of range [0] with length 0
	.../resource/gomega.go:45
exit=2

after:
Command: echo hi: stdout:
Error
    Syntax Error: Invalid matcher configuration. An empty map asserts nothing, exactly one matcher is required
Count: 2, Failed: 1, Skipped: 0
exit=1
```

Same for `listening: {}` and for a nested one such as `{"and": [{}]}`.

## Cause

`matcherToGomegaMatcher` guards the "too many keys" case but not the "no keys"
case, then indexes unconditionally:

```go
keys := lo.Keys(matcherMap)
if len(keys) > 1 {
    return nil, fmt.Errorf("Syntax Error: ... Found multiple matchers: %q", keys)
}
key := keys[0]
```

An empty map reaches `keys[0]` with a zero-length slice.

## The fix

The mirror image of the existing guard: return a syntax error when there are no
keys, in the same style and phrasing as the neighbouring one, so a malformed
gossfile is reported as malformed rather than crashing the run.

## Verification

`TestMatcherToGomegaMatcherEmptyMap` covers the empty map at the top level and
nested inside `and` and `not`.

Two mutations, because "it panics" and "it returns the right thing" are separate
claims:

Removing the guard reproduces the original crash:

```
--- FAIL: TestMatcherToGomegaMatcherEmptyMap/top_level
panic: runtime error: index out of range [0] with length 0 [recovered, repanicked]
```

Returning a matcher instead of the error fails on the assertion, not on a panic,
which is what shows the test checks the behaviour rather than merely surviving:

```
Error: Expected nil, but got: &matchers.EqualMatcher{...Expected:interface {}(nil)}
Error: Expected error with "Syntax Error: Invalid matcher configuration. An empty map asserts nothing, exactly one matcher is required" in chain but got nil.
```

`go test ./...` is ok across all packages, and `golangci-lint run ./resource/...`
reports 0 issues.

On the golden fixtures: this change only affects an input that previously
crashed, so no generated output string changes. I grepped `integration-tests/`
and `docs/` for both the old and new strings and there are no hits, so no
`goss-expected*.yaml` needs updating.

##### Checklist

- [ ] `make test-all` (UNIX) passes. CI will also test this (could not run in full here: it needs Docker. `go test ./...` and `golangci-lint` pass, and the before/after above comes from running real binaries built from each tree)
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable) (no doc change: an empty map was never valid, it just failed badly)

One note unrelated to the fix: `gofumpt -l resource/` lists `gomega.go` both
before and after this change, so I left the pre-existing formatting alone rather
than mixing a reformat into this diff.

*Disclosure: written with AI assistance (Claude Code). I built binaries from master and from the patched tree, produced the before and after above by running them against the gossfile shown, and ran both mutation checks myself.*
