### PR TITLE
feat(add): --exact-match flag for the command generator

### DIFF
--- a/cmd/goss/goss.go
+++ b/cmd/goss/goss.go
@@ -28,6 +28,7 @@ func newRuntimeConfigFromCLI(c *cli.Command) *util.Config {
 		Debug:             c.Bool("debug"),
 		LogLevel:          c.String("log-level"),
 		Endpoint:          c.String("endpoint"),
+		ExactMatch:        c.Bool("exact-match"),
 		FormatOptions:     c.StringSlice("format-options"),
 		IgnoreList:        c.StringSlice("exclude-attr"),
 		ListenAddress:     c.String("listen-addr"),
@@ -320,6 +321,10 @@ func main() {
 						Usage: "add new command",
 						Flags: []cli.Flag{
 							timeoutFlag(10 * time.Second),
+							&cli.BoolFlag{
+								Name:  "exact-match",
+								Usage: "capture stdout/stderr as a single string and assert an exact, whitespace-sensitive match instead of per-line patterns",
+							},
 						},
 						Action: func(ctx context.Context, c *cli.Command) error {
 							fatalAlphaIfNeeded(c)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -105,12 +105,18 @@ A sub-command *resource type* has to be provided when running `add`.
 :   Ignore **non-required** attribute(s) matching the provided glob when adding a new resource,
     may be specified multiple times.
 
+`--exact-match`
+:   Only for `command`. Capture `stdout`/`stderr` as a single string so `goss validate`
+    asserts an exact, whitespace and newline sensitive match rather than per-line patterns.
+    Useful for golden master / approval style tests.
+
 !!! example
     ```console
     goss add file /etc/passwd
     goss a user nobody
     goss add --exclude-attr home --exclude-attr shell user nobody
     goss a --exclude-attr '*' user nobody
+    goss add command --exact-match 'kubectl get pod mypod -o yaml'
     ```
 
 #### Resources types

--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -173,7 +173,11 @@ command:
     retry_delay: 500  # Delay in milliseconds before each retry; duration strings like 500ms or 2s also work
 ```
 
-`stdout` and `stderr` can be a string or [pattern](#patterns)
+`stdout` and `stderr` can be a string or [pattern](#patterns). A list of
+patterns each has to be found somewhere in the output, while a single string is
+compared for an exact match, so whitespace and line breaks have to line up. That
+exact form is handy for golden master or approval style tests where the whole
+output matters; `goss add command --exact-match` generates it for you.
 
 !!! warning "An empty list asserts nothing"
 

--- a/integration-tests/goss/goss-shared.yaml
+++ b/integration-tests/goss/goss-shared.yaml
@@ -27,6 +27,12 @@ command:
     exit-status: 0
     stdout:
     - /Linux/
+  command-exact-match:
+    exec: printf 'goss-exact-match'
+    exit-status: 0
+    # A single string (rather than a list) is matched exactly, which is what
+    # `goss add command --exact-match` generates.
+    stdout: goss-exact-match
 file:
 {{range mkSlice "/etc/PAsswD" "/etc/group"}}
   {{. | toLower}}:

--- a/integration-tests/test.sh
+++ b/integration-tests/test.sh
@@ -44,9 +44,9 @@ out=$(docker_exec "/goss/$os/goss-linux-$arch" --vars "/goss/vars.yaml" --vars-i
 echo "$out"
 
 if [[ $os == "arch" ]]; then
-    egrep -q 'Count: 112, Failed: 0, Skipped: 3' <<<"$out"
+    egrep -q 'Count: 114, Failed: 0, Skipped: 3' <<<"$out"
 else
-    egrep -q 'Count: 133, Failed: 0, Skipped: 5' <<<"$out"
+    egrep -q 'Count: 135, Failed: 0, Skipped: 5' <<<"$out"
 fi
 
 if [[ ! $os == "arch" ]]; then

--- a/resource/command.go
+++ b/resource/command.go
@@ -103,20 +103,38 @@ func NewCommand(sysCommand system.Command, config util.Config) (*Command, error)
 
 	if !contains(config.IgnoreList, "stdout") {
 		stdout, _ := sysCommand.Stdout()
-		outSlice := readerToSlice(stdout)
-		if len(outSlice) != 0 {
-			c.Stdout = outSlice
+		if out := readerToMatcher(stdout, config.ExactMatch); out != nil {
+			c.Stdout = out
 		}
 	}
 	if !contains(config.IgnoreList, "stderr") {
 		stderr, _ := sysCommand.Stderr()
-		errSlice := readerToSlice(stderr)
-		if len(errSlice) != 0 {
-			c.Stderr = errSlice
+		if out := readerToMatcher(stderr, config.ExactMatch); out != nil {
+			c.Stderr = out
 		}
 	}
 
 	return c, err
+}
+
+// readerToMatcher turns captured command output into the matcher goss writes
+// for it. By default that's a list of trimmed lines, matched as patterns. With
+// exactMatch it's the raw output as a single string, which goss validates for
+// an exact (whitespace and newline sensitive) match. It returns nil when there
+// is nothing to assert so the caller can leave the default empty value in place.
+func readerToMatcher(reader io.Reader, exactMatch bool) matcher {
+	if exactMatch {
+		b, _ := io.ReadAll(reader)
+		if len(b) == 0 {
+			return nil
+		}
+		return string(b)
+	}
+	slice := readerToSlice(reader)
+	if len(slice) == 0 {
+		return nil
+	}
+	return slice
 }
 
 func escapePattern(s string) string {

--- a/resource/command.go
+++ b/resource/command.go
@@ -115,13 +115,21 @@ func NewCommand(sysCommand system.Command, config util.Config) (*Command, error)
 
 	if !contains(config.IgnoreList, "stdout") {
 		stdout, _ := sysCommand.Stdout()
-		if out := readerToMatcher(stdout, config.ExactMatch); out != nil {
+		out, rerr := readerToMatcher(stdout, config.ExactMatch)
+		if rerr != nil {
+			return c, rerr
+		}
+		if out != nil {
 			c.Stdout = out
 		}
 	}
 	if !contains(config.IgnoreList, "stderr") {
 		stderr, _ := sysCommand.Stderr()
-		if out := readerToMatcher(stderr, config.ExactMatch); out != nil {
+		out, rerr := readerToMatcher(stderr, config.ExactMatch)
+		if rerr != nil {
+			return c, rerr
+		}
+		if out != nil {
 			c.Stderr = out
 		}
 	}
@@ -134,19 +142,22 @@ func NewCommand(sysCommand system.Command, config util.Config) (*Command, error)
 // exactMatch it's the raw output as a single string, which goss validates for
 // an exact (whitespace and newline sensitive) match. It returns nil when there
 // is nothing to assert so the caller can leave the default empty value in place.
-func readerToMatcher(reader io.Reader, exactMatch bool) matcher {
+func readerToMatcher(reader io.Reader, exactMatch bool) (matcher, error) {
 	if exactMatch {
-		b, _ := io.ReadAll(reader)
-		if len(b) == 0 {
-			return nil
+		b, err := io.ReadAll(reader)
+		if err != nil {
+			return nil, err
 		}
-		return string(b)
+		if len(b) == 0 {
+			return nil, nil
+		}
+		return string(b), nil
 	}
 	slice := readerToSlice(reader)
 	if len(slice) == 0 {
-		return nil
+		return nil, nil
 	}
-	return slice
+	return slice, nil
 }
 
 func escapePattern(s string) string {

--- a/resource/command_test.go
+++ b/resource/command_test.go
@@ -76,7 +76,7 @@ func TestNewCommandExactMatchHonorsIgnoreList(t *testing.T) {
 	}
 	if got, ok := c.Stderr.(string); !ok || got != "some error\n" {
 		t.Fatalf("Stderr = %#v, want captured raw string", c.Stderr)
-  }
+	}
 }
 
 func TestCommandGetExec(t *testing.T) {

--- a/resource/command_test.go
+++ b/resource/command_test.go
@@ -1,0 +1,79 @@
+package resource
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/goss-org/goss/util"
+)
+
+func newFakeCommand(stdout, stderr string) *fakeCommand {
+	return &fakeCommand{
+		command:      "some-command",
+		exitStatusFn: func() (int, error) { return 0, nil },
+		stdoutFn:     func() (io.Reader, error) { return strings.NewReader(stdout), nil },
+		stderrFn:     func() (io.Reader, error) { return strings.NewReader(stderr), nil },
+	}
+}
+
+func TestNewCommandDefaultCapturesTrimmedLines(t *testing.T) {
+	sysCommand := newFakeCommand("line one\n  indented two\nline three\n", "")
+
+	c, err := NewCommand(sysCommand, util.Config{})
+	if err != nil {
+		t.Fatalf("NewCommand returned error: %v", err)
+	}
+
+	want := []string{"line one", "indented two", "line three"}
+	if got, ok := c.Stdout.([]string); !ok || !reflect.DeepEqual(got, want) {
+		t.Fatalf("Stdout = %#v, want %#v", c.Stdout, want)
+	}
+}
+
+func TestNewCommandExactMatchCapturesRawString(t *testing.T) {
+	raw := "line one\n  indented two\nline three\n"
+	sysCommand := newFakeCommand(raw, "")
+
+	c, err := NewCommand(sysCommand, util.Config{ExactMatch: true})
+	if err != nil {
+		t.Fatalf("NewCommand returned error: %v", err)
+	}
+
+	if got, ok := c.Stdout.(string); !ok || got != raw {
+		t.Fatalf("Stdout = %#v, want exact %#v", c.Stdout, raw)
+	}
+}
+
+func TestNewCommandExactMatchLeavesEmptyOutputUnset(t *testing.T) {
+	sysCommand := newFakeCommand("", "")
+
+	c, err := NewCommand(sysCommand, util.Config{ExactMatch: true})
+	if err != nil {
+		t.Fatalf("NewCommand returned error: %v", err)
+	}
+
+	if got, ok := c.Stdout.(string); !ok || got != "" {
+		t.Fatalf("Stdout = %#v, want empty string", c.Stdout)
+	}
+	if got, ok := c.Stderr.(string); !ok || got != "" {
+		t.Fatalf("Stderr = %#v, want empty string", c.Stderr)
+	}
+}
+
+func TestNewCommandExactMatchHonorsIgnoreList(t *testing.T) {
+	sysCommand := newFakeCommand("some output\n", "some error\n")
+
+	c, err := NewCommand(sysCommand, util.Config{ExactMatch: true, IgnoreList: []string{"stdout"}})
+	if err != nil {
+		t.Fatalf("NewCommand returned error: %v", err)
+	}
+
+	if got, ok := c.Stdout.(string); !ok || got != "" {
+		t.Fatalf("Stdout = %#v, want empty string when ignored", c.Stdout)
+	}
+	if got, ok := c.Stderr.(string); !ok || got != "some error\n" {
+		t.Fatalf("Stderr = %#v, want captured raw string", c.Stderr)
+	}
+}

--- a/resource/command_test.go
+++ b/resource/command_test.go
@@ -12,7 +12,7 @@ import (
 
 func newFakeCommand(stdout, stderr string) *fakeCommand {
 	return &fakeCommand{
-		command:      "some-command",
+		command:      util.ExecCommand{CmdStr: "some-command"},
 		exitStatusFn: func() (int, error) { return 0, nil },
 		stdoutFn:     func() (io.Reader, error) { return strings.NewReader(stdout), nil },
 		stderrFn:     func() (io.Reader, error) { return strings.NewReader(stderr), nil },

--- a/util/config.go
+++ b/util/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	Cache                 time.Duration
 	Debug                 bool
 	Endpoint              string
+	ExactMatch            bool
 	FormatOptions         []string
 	IgnoreList            []string
 	ListenAddress         string


### PR DESCRIPTION
Implements the approved feature request in #947.

`goss add command` records stdout/stderr as a list of trimmed lines, which validate then treats as patterns. That's great for most checks, but it drops whitespace, blank lines and ordering, so you can't use it for approval / golden master style tests where the whole output matters (the issue's example is yaml).

This adds a `--exact-match` flag to `goss add command`. When set, the generator keeps the raw output as a single string, which goss already validates as an exact, whitespace sensitive match via the string form of `stdout`/`stderr`. Nothing changes without the flag.

Before:

```console
$ goss add command "printf 'line one\n  indented two\n'"
```
```yaml
command:
  printf 'line one\n  indented two\n':
    exit-status: 0
    stdout:
      - line one
      - indented two
    stderr: ""
```

After, with `--exact-match`:

```yaml
command:
  printf 'line one\n  indented two\n':
    exit-status: 0
    stdout: |
      line one
        indented two
    stderr: ""
```

The second one fails validation if the indentation or a newline drifts, which is the point.

##### Checklist

- [x] `make test-all` (UNIX) passes. CI will also test this
- [x] unit and/or integration tests are included (if applicable)
- [x] documentation is changed or added (if applicable)

### Description of change

CLI flag on the `command` add subcommand, threaded through `util.Config.ExactMatch` into `NewCommand`, which picks the raw string instead of the trimmed line slice. Added `resource/command_test.go` covering the default, exact-match, empty-output and `--exclude-attr` cases, and documented the flag in `docs/cli.md` and the command section of `docs/gossfile.md`.


<!-- readthedocs-preview goss start -->
----
📚 Documentation preview 📚: https://goss--1122.org.readthedocs.build/en/1122/

<!-- readthedocs-preview goss end -->