### PR TITLE
fix(matchers): report a syntax error for matcher groups with no sub-matchers

### DIFF
--- a/docs/gossfile.md
+++ b/docs/gossfile.md
@@ -816,6 +816,29 @@ Count: 1, Failed: 1, Skipped: 0
 
 Goss supports advanced matchers by converting YAML input to [gomega](https://onsi.github.io/gomega/) matchers.
 
+!!! warning "An empty matcher group is a syntax error"
+
+    A matcher group is a set of conditions that must all be satisfied. A group
+    holding no conditions asserts nothing and would report a pass without the
+    value ever being looked at, so goss rejects it:
+
+    ```yaml
+    and: []               # syntax error
+    contain-elements: []  # syntax error
+    gjson: {}             # syntax error
+    ```
+
+    Two others look similar and are still accepted, because neither can pass
+    without checking the value:
+
+    ```yaml
+    consist-of: []        # asserts the value is empty
+    or: []                # can never be satisfied
+    ```
+
+    This is a change in behaviour. A gossfile containing one of the first three
+    used to be reported as passing.
+
 #### String Matchers
 
 These will convert the system attribute to a string prior to matching.

--- a/resource/gomega.go
+++ b/resource/gomega.go
@@ -11,7 +11,15 @@ import (
 var (
 	errMissingRequiredAttribute = errors.New("Syntax Error: Missing required attribute")
 	errEmptyMatcher             = errors.New("Syntax Error: Invalid matcher configuration. An empty map asserts nothing, exactly one matcher is required")
+	errEmptyMatcherGroup        = errors.New("asserts nothing, at least one matcher is required")
 )
+
+// emptyMatcherGroupError reports a matcher that reduces to no sub-matchers at
+// all. Gomega treats that as vacuously true, so the test would be reported as
+// passing without ever looking at the value.
+func emptyMatcherGroupError(name string) error {
+	return fmt.Errorf("Syntax Error: Invalid '%s' argument. An empty value %w", name, errEmptyMatcherGroup)
+}
 
 func matcherToGomegaMatcher(matcher any) (matchers.GossMatcher, error) {
 	// Default matchers
@@ -119,6 +127,9 @@ func matcherToGomegaMatcher(matcher any) (matchers.GossMatcher, error) {
 		if err != nil {
 			return nil, err
 		}
+		if len(subMatchers) == 0 {
+			return nil, emptyMatcherGroupError(matchType)
+		}
 		var interfaceSlice []any
 		for _, d := range subMatchers {
 			interfaceSlice = append(interfaceSlice, d)
@@ -144,6 +155,9 @@ func matcherToGomegaMatcher(matcher any) (matchers.GossMatcher, error) {
 		subMatchers, err := sliceToGomega(value, "and")
 		if err != nil {
 			return nil, err
+		}
+		if len(subMatchers) == 0 {
+			return nil, emptyMatcherGroupError(matchType)
 		}
 		return matchers.And(subMatchers...), nil
 	case "or":
@@ -195,6 +209,9 @@ func matcherToGomegaMatcher(matcher any) (matchers.GossMatcher, error) {
 		valueI, ok := value.(map[string]any)
 		if !ok {
 			return nil, invalidArgSyntaxError("gjson", "map", value)
+		}
+		if len(valueI) == 0 {
+			return nil, emptyMatcherGroupError(matchType)
 		}
 		for key, val := range valueI {
 			subMatcher, err := matcherToGomegaMatcher(val)

--- a/resource/gomega_test.go
+++ b/resource/gomega_test.go
@@ -188,3 +188,45 @@ func TestMatcherToGomegaMatcherEmptyMap(t *testing.T) {
 		})
 	}
 }
+
+// A matcher group with no sub-matchers is vacuously true in Gomega, so these
+// used to be reported as passing without ever looking at the value.
+func TestMatcherToGomegaMatcherEmptyGroup(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{name: "and", in: `{"and": []}`},
+		{name: "contain-elements", in: `{"contain-elements": []}`},
+		{name: "gjson", in: `{"gjson": {}}`},
+		{name: "nested in not", in: `{"not": {"and": []}}`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			var dat any
+			if err := json.Unmarshal([]byte(c.in), &dat); err != nil {
+				t.Fatal(err)
+			}
+
+			got, err := matcherToGomegaMatcher(dat)
+			assert.Nil(t, got)
+			assert.ErrorIs(t, err, errEmptyMatcherGroup)
+		})
+	}
+}
+
+// consist-of and or are meaningful when empty: the first asserts that the value
+// is empty, the second can never be satisfied. Neither reports a false pass.
+func TestMatcherToGomegaMatcherEmptyGroupExceptions(t *testing.T) {
+	for _, in := range []string{`{"consist-of": []}`, `{"or": []}`} {
+		var dat any
+		if err := json.Unmarshal([]byte(in), &dat); err != nil {
+			t.Fatal(err)
+		}
+
+		got, err := matcherToGomegaMatcher(dat)
+		assert.NoError(t, err, in)
+		assert.NotNil(t, got, in)
+	}
+}


### PR DESCRIPTION
##### Checklist

- [ ] `make test-all` (UNIX) passes. CI will also test this
  - the Makefile has no `test-all` target, so I left this unticked rather than tick it for something else. `make test-short-all` (fmt, lint, vet, test) passes in full. The `test-int-*` targets need a Docker daemon; no fixture in the repo contains any of the affected shapes, grepped for `and: []`, `contain-elements: []` and `gjson: {}` across every yaml, json and golden file.
- [x] unit and/or integration tests are included (if applicable)
- [ ] documentation is changed or added (if applicable)
  - `docs/gossfile.md` already documents these as `and: [matcher, ..]` and `contain-elements: [matcher, ...]`, so the change makes the behaviour match the documented contract rather than altering it.

### Description of change

Gomega's `And()` with zero matchers is vacuously true, so a matcher group that reduces to no sub-matchers is reported as a pass without the value ever being looked at.

```yaml
user:
  orca:
    groups:
      and: []
```

```
ok 3 - User: orca: groups: matches expectation: {"and":[]}
```

`orca` is in exactly one group, and any assertion about it would have been checked. `and: []` checks nothing and still prints `ok`. The same holds for `contain-elements: []` and `gjson: {}`.

Two siblings in the same function already behave correctly and are deliberately left alone:

| matcher | before | after |
| --- | --- | --- |
| `and: []` | `ok`, asserts nothing | syntax error |
| `contain-elements: []` | `ok`, asserts nothing | syntax error |
| `gjson: {}` | `ok`, asserts nothing | syntax error |
| `consist-of: []` | fails | unchanged, it asserts the value is empty |
| `or: []` | fails | unchanged, it can never be satisfied |

Neither of the last two can produce a false pass, so neither is a syntax error.

This is the same treatment an empty matcher map already gets from `errEmptyMatcher` in #1118.

Worth flagging: a gossfile that contains one of these three today goes from passing to failing. That is the point of the change, but it will surface in existing suites, so it is a behaviour change and not purely a bug fix from the user's side.

Not included, because it overlaps with my open #1114: a bare empty list at the top level of an attribute (`groups: []`) is also vacuously true. #1114 proposes warning on those at the resource layer, and turning the same input into a hard error here would work against it. Happy to fold it in either way once #1114 is resolved.

### Verification

Ran against the built binary on a real gossfile, before and after, for all five shapes in the table. `and: []`, `contain-elements: []` and `gjson: {}` flip from `ok` to a syntax error; `consist-of: []` and `or: []` are byte-identical; `contain-elements: ["orca"]` still passes.

Four test cases added, plus one asserting the two exceptions still build a matcher. Dropping any one of the three guards fails exactly its own subtest and no other:

| guard removed | subtest that fails |
| --- | --- |
| `and` | `EmptyGroup/and` and `EmptyGroup/nested_in_not` |
| `contain-elements` | `EmptyGroup/contain-elements` |
| `gjson` | `EmptyGroup/gjson` |

`make test-short-all` passes, and `golangci-lint run ./resource/...` reports 0 issues.

AI disclosure: written with Claude Code. I ran the binary before and after and ran the mutations myself.
